### PR TITLE
MS VC++で警告が出ないように修正 / 特に _CRT_SECURE_NO_WARNINGS フラグを外し文字列関数にセキュア版(_s…

### DIFF
--- a/Source/bdhpri.c
+++ b/Source/bdhpri.c
@@ -21,7 +21,6 @@
 	
 ****************/
 
-#define _CRT_SECURE_NO_WARNINGS
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -51,9 +50,9 @@ void	bdhpri ( char *ofile, RMVLS rmvls, EXSFS *exs )
 	else
 		room = NULL ;
 	
-	strcpy ( file, ofile ) ;
-	strcat ( file, "_bdh.es" ) ;
-	fp = fopen ( file, "w" ) ;
+	strcpy_s ( file, sizeof(file), ofile ) ;
+	strcat_s ( file, sizeof(file), "_bdh.es" ) ;
+	fopen_s (&fp, file, "w" ) ;
 	
 	fprintf ( fp, "%d\n", Nroom ) ;
 	
@@ -88,7 +87,7 @@ void	bdhpri ( char *ofile, RMVLS rmvls, EXSFS *exs )
 			
 			if ( r->A < 0.0 )
 			{
-				sprintf ( E, "RmName=%s Ble=%c A=%.3lf\n", room->name, r->ble, r->A ) ;
+				sprintf_s ( E, sizeof(E), "RmName=%s Ble=%c A=%.3lf\n", room->name, r->ble, r->A ) ;
 				Errprint ( 1, "<bdhpri>", E ) ;
 			}
 			
@@ -96,7 +95,7 @@ void	bdhpri ( char *ofile, RMVLS rmvls, EXSFS *exs )
 				fprintf ( fp, "%.3lf\t%.2lf\t;\n", r->Rwall, r->CAPwall ) ;
 			else
 			{
-				sprintf ( E, "Rmname=%s Ble=%c  Not Defined", room->name, r->ble ) ;
+				sprintf_s ( E, sizeof(E), "Rmname=%s Ble=%c  Not Defined", room->name, r->ble ) ;
 				//Errprint ( 1, "<bdhpri>", E ) ;
 				fprintf(fp, "\t\t;\n");
 			}

--- a/Source/bl/blhcflib.c
+++ b/Source/bl/blhcflib.c
@@ -15,7 +15,6 @@
 
 /*    bhcflib.c            */
 
-#define _CRT_SECURE_NO_WARNINGS
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/Source/bl/blhelm.c
+++ b/Source/bl/blhelm.c
@@ -15,7 +15,7 @@
 
 /* helm.c */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdlib.h>
 #include "MODEL.h" /*----higuchi 070918--*/
 #include "fesy.h"
@@ -353,9 +353,9 @@ void helmsfprint( FILE *fo, int id, int Nroom, ROOM *Room)
 				if (Sd->sfepri == 'y')
 				{
 					if (strlen(Sd->name) == 0)
-						sprintf(s, "%s-%d-%c", Room->name, j, Sd->ble);
+						sprintf_s(s, sizeof(s), "%s-%d-%c", Room->name, j, Sd->ble);
 					else
-						sprintf(s, "%s-%s", Room->name, Sd->name);
+						sprintf_s(s, sizeof(s), "%s-%s", Room->name, Sd->name);
 					
 					fprintf (fo, "%s_trs t f %s_so f %s_sg t f ", s, s, s);
 					fprintf (fo, "%s_rn t f %s_in t f %s_pnl t f\n", s, s, s);

--- a/Source/bl/blinit.c
+++ b/Source/bl/blinit.c
@@ -14,7 +14,7 @@
 //along with Foobar.If not, see < https://www.gnu.org/licenses/>.
 
 /*   binit.c   */
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <malloc.h>
@@ -42,11 +42,11 @@ void Walldata (FILE *fi, FILE *fbmlist, char *dsn,
 	// void Walli();
 	
 	W = NULL ;
-	sprintf (E, ERRFMT, dsn);
+	sprintf_s (E, sizeof(E), ERRFMT, dsn);
 	
 	Nw = wbmlistcount ( fbmlist ) ;
 	
-	strcpy ( s, "Walldata wbmlist.efl--" ) ;
+	strcpy_s ( s, sizeof(s), "Walldata wbmlist.efl--" ) ;
 	
 	if ( Nw > 0 )
 	{
@@ -64,11 +64,11 @@ void Walldata (FILE *fi, FILE *fbmlist, char *dsn,
 	
 	k = 0 ;
 	Wl = W ;
-	while (fscanf(fbmlist, "%s", s) != EOF, *s != '*')
+	while (fscanf_s(fbmlist, "%s", s, sizeof(s)) != EOF, *s != '*')
 	{
 		if (strcmp(s,"!") == 0)
 		{
-			while (fscanf(fbmlist,"%c", &c), c != '\n' )
+			while (fscanf_s(fbmlist,"%c", &c, 1), c != '\n' )
 				;
 		}
 		
@@ -98,13 +98,13 @@ void Walldata (FILE *fi, FILE *fbmlist, char *dsn,
 				if ( Wl->mcode != NULL && Wc->mcode != NULL
 					&& strcmp ( Wl->mcode, Wc->mcode ) == 0 )
 				{
-					sprintf ( s, "wbmlist.efl duplicate code=<%s>",
+					sprintf_s ( s, sizeof(s), "wbmlist.efl duplicate code=<%s>",
 						Wl->mcode ) ;
 					Eprint ( "<Walldata>", s ) ;
 				}
 			}
 
-			fscanf(fbmlist, "%lf %lf", &Wl->Cond, &Wl->Cro);
+			fscanf_s(fbmlist, "%lf %lf", &Wl->Cond, &Wl->Cro);
 			// Cond：熱伝導率［W/mK］、Cro：容積比熱［kJ/m3K］
 			
 			//for ( j=0; j<k+1; j++)
@@ -129,7 +129,7 @@ void Walldata (FILE *fi, FILE *fbmlist, char *dsn,
 	
 	N = Wallcount ( fi ) ;
 	
-	strcpy ( s, "Walldata --" ) ;
+	strcpy_s ( s, sizeof(s), "Walldata --" ) ;
 	
 	if ( N > 0 )
 	{
@@ -190,7 +190,7 @@ void Walldata (FILE *fi, FILE *fbmlist, char *dsn,
 	}
 	
 	Wa = *Wall ;
-	while (fscanf(fi, " %s ",s) != EOF)
+	while (fscanf_s(fi, " %s ", s, sizeof(s)) != EOF)
 	{
 		//printf( "<WAlldata> 1.... s=%s\n", s ) ;
 		
@@ -241,7 +241,7 @@ void Walldata (FILE *fi, FILE *fbmlist, char *dsn,
 		
 		j= -1;
 		
-		while (fscanf(fi, "%s", s), *s != ';')
+		while (fscanf_s(fi, "%s", s, sizeof(s)), *s != ';')
 		{
 			//printf ( "<Walldata> 2..... s=%s\n", s ) ;
 			
@@ -335,7 +335,7 @@ void Walldata (FILE *fi, FILE *fbmlist, char *dsn,
 			else
 			{
 				j++ ;
-				strcpy(layer[j], s);
+				strcpy_s(layer[j], SCHAR, s);
 			}
 			
 			if (ce) break;
@@ -379,7 +379,7 @@ void Walldata (FILE *fi, FILE *fbmlist, char *dsn,
 				w->code = stralloc (layer[jj] ) ;
 				
 				// 同一層内の内部分割数の計算
-				ndat = sscanf(st+1, "%lf/%d", &dt, &ndiv);
+				ndat = sscanf_s(st+1, "%lf/%d", &dt, &ndiv);
 				if (ndat == 1)
 					w->ND = (int)(dt>=50. ? (dt-50.)/50. : 0);
 				else
@@ -450,21 +450,21 @@ void Walldata (FILE *fi, FILE *fbmlist, char *dsn,
 				}
 				else
 				{
-					sprintf ( s, "ble=%c name=%s 建築一体型空気集熱の熱貫流率Ku、Kdが未定義です",
+					sprintf_s ( s, sizeof(s), "ble=%c name=%s 建築一体型空気集熱の熱貫流率Ku、Kdが未定義です",
 						Wa->ble, Wa->name ) ;
 					Eprint ( "<Walldata>", s ) ;
 				}
 
 				if (Wa->chrRinput == 'N' && (Wa->Kc < 0. || Wa->Ksu < 0. || Wa->Ksd < 0. ))
 				{
-					sprintf ( s, "ble=%c name=%s 建築一体型空気集熱の熱貫流率Kc、Kdd、Kudが未定義です",
+					sprintf_s ( s, sizeof(s), "ble=%c name=%s 建築一体型空気集熱の熱貫流率Kc、Kdd、Kudが未定義です",
 						Wa->ble, Wa->name ) ;
 					Eprint ( "<Walldata>", s ) ;
 				}
 
 				if ( Wa->Ip == -1 )
 				{
-					sprintf ( s, "ble=%c name=%s 建築一体型空気集熱の空気流通層<P>が未定義です",
+					sprintf_s ( s, sizeof(s), "ble=%c name=%s 建築一体型空気集熱の空気流通層<P>が未定義です",
 						Wa->ble, Wa->name ) ;
 					Eprint ( "<Walldata>", s ) ;
 				}
@@ -508,7 +508,7 @@ void Windowdata (FILE *fi, char *dsn, WINDOW **Window, int *Nwindow)
 	//double  dt;
 	WINDOW	*W, *Wc ;
 	
-	sprintf (E, ERRFMT, dsn);
+	sprintf_s (E, sizeof(E), ERRFMT, dsn);
 	
 	N = Wallcount ( fi ) ;
 
@@ -534,7 +534,7 @@ void Windowdata (FILE *fi, char *dsn, WINDOW **Window, int *Nwindow)
 	}
 
 	W = *Window ;
-	while (fscanf(fi, "%s", s), *s != '*')
+	while (fscanf_s(fi, "%s", s, sizeof(s)), *s != '*')
 	{ 
 		i++ ;
 		
@@ -553,12 +553,12 @@ void Windowdata (FILE *fi, char *dsn, WINDOW **Window, int *Nwindow)
 			if ( W->name != NULL && Wc->name != NULL
 				&& strcmp ( W->name, Wc->name ) == 0 )
 			{
-				sprintf ( ss, "<WINDOW>  WindowName Already Defined  (%s)", W->name ) ;
+				sprintf_s ( ss, sizeof(ss), "<WINDOW>  WindowName Already Defined  (%s)", W->name ) ;
 				Eprint ( "<Windowdata>", ss ) ;
 			}
 		}
 		
-		while (fscanf (fi, "%s",s), *s != ';')
+		while (fscanf_s (fi, "%s", s, sizeof(s)), *s != ';')
 		{ 
 			// 室内透過日射が窓室内側への入射日射を屋外に透過する場合'y'
 			if (strcmp(s, "-RStrans") == 0)
@@ -591,7 +591,7 @@ void Windowdata (FILE *fi, char *dsn, WINDOW **Window, int *Nwindow)
 					W->Cidtype = NULL;
 					if (*st == '\'')
 					{
-						sscanf(st + 1, "%[^']", s);
+						sscanf_s(st + 1, "%[^']", s, sizeof(s));
 						W->Cidtype = stralloc(s);
 					}
 					else
@@ -609,7 +609,7 @@ void Windowdata (FILE *fi, char *dsn, WINDOW **Window, int *Nwindow)
 				//	W->AirFlowcat.alr =dt;
 				else
 				{
-					sprintf("%s %s\n", E, s);
+					sprintf_s(Err, sizeof(Err), "%s %s\n", E, s);
 					Eprint("<Windowdata>", Err);
 				}
 			}
@@ -661,7 +661,7 @@ void Snbkdata (FILE *fi, char *dsn, SNBK **Snbk)
 	
 	SNBK	*S ;
 	
-	sprintf(Er, ERRFMT, dsn);
+	sprintf_s(Er, sizeof(Er), ERRFMT, dsn);
 	type = 0 ;
 	
 	N = Wallcount ( fi ) ;
@@ -682,7 +682,7 @@ void Snbkdata (FILE *fi, char *dsn, SNBK **Snbk)
 	}
 
 	S = *Snbk ;
-	while (fscanf(fi, " %s", name), *name != '*')
+	while (fscanf_s(fi, " %s", name, sizeof(s)), *name != '*')
 	{
 		i++ ;
 		
@@ -694,14 +694,14 @@ void Snbkdata (FILE *fi, char *dsn, SNBK **Snbk)
 		/*************************************/
 
 		S->name = stralloc ( name ) ;
-		strcpy(code, ".......");
+		strcpy_s(code, sizeof(code), ".......");
 		
-		while (fscanf(fi, " %s" ,s),  *s != ';')
+		while (fscanf_s(fi, " %s", s, sizeof(s)),  *s != ';')
 		{
 			if ((ce=strchr(s, ';')) != 0)
 				*ce = '\0';
 
-			sscanf(s, "%[^=]=%s", key, v);
+			sscanf_s(s, "%[^=]=%s", key, sizeof(key), v, sizeof(v));
 			if (strcmp(key, "type") == 0)
 			{
 				vs = v ;
@@ -725,13 +725,13 @@ void Snbkdata (FILE *fi, char *dsn, SNBK **Snbk)
 					type = 9;
 				else
 				{
-					sprintf ( E, "%s %s %s\n", Er, name, s);
+					sprintf_s ( E, sizeof(E), "%s %s %s\n", Er, name, s);
 					Eprint ( "<Snbkdata>", E ) ;
 				}
 			}
 			else if (strcmp(key, "window") == 0)
 			{
-				sscanf(v, "%c%lfx%c%lf", &k[0], &val[0], &k[1], &val[1]);
+				sscanf_s(v, "%c%lfx%c%lf", &k[0], 1, &val[0], &k[1], 1, &val[1]);
 				for (j=0; j<2; j++)
 				{
 					if (k[j] == 'H')
@@ -740,7 +740,7 @@ void Snbkdata (FILE *fi, char *dsn, SNBK **Snbk)
 						S->W = val[j], code[1] = 'W';
 					else
 					{
-						sprintf ( E, "%s %s %c\n", Er, S->name, k[j] );
+						sprintf_s ( E, sizeof(E), "%s %s %c\n", Er, S->name, k[j] );
 						Eprint ( "<Snbkdata>", E ) ;
 					}
 				}
@@ -757,7 +757,7 @@ void Snbkdata (FILE *fi, char *dsn, SNBK **Snbk)
 				S->H2 = atof(v), code[6] = 'B';
 			else
 			{
-				sprintf ( E, "%s %s %s\n", Er, name, s) ;
+				sprintf_s ( E, sizeof(E), "%s %s %s\n", Er, name, s) ;
 				Eprint ( "<Snbkdata>", E ) ;
 			}
 			
@@ -769,7 +769,7 @@ void Snbkdata (FILE *fi, char *dsn, SNBK **Snbk)
 		case 1: case 5: case 9:
 			if (strcmp(code, typstr[type-1]) != 0)
 			{
-				sprintf(E, "%s %s  type=%d %s\n", Er, name, type, code);
+				sprintf_s(E, sizeof(E), "%s %s  type=%d %s\n", Er, name, type, code);
 				Eprint ( "<Snbkdata>", E ) ;
 			}
 			break;
@@ -785,7 +785,7 @@ void Snbkdata (FILE *fi, char *dsn, SNBK **Snbk)
 					}   
 					if (j == 3)
 					{
-						sprintf(E,"%s %s  type=%d %s\n", Er, name, type, code);
+						sprintf_s(E, sizeof(E), "%s %s  type=%d %s\n", Er, name, type, code);
 						Eprint ( "<Snbkdata>", E ) ;
 					}
 				}
@@ -1024,18 +1024,18 @@ int		wbmlistcount ( FILE *fi )
 	int		N = 0 ;
 	char	s[SCHAR], c ;
 	
-	while ( fscanf ( fi, "%s", s ) != EOF, *s != '*' )
+	while ( fscanf_s ( fi, "%s", s, sizeof(s) ) != EOF, *s != '*' )
 	{
 		if ( strcmp(s,"!") == 0)
 		{
-			while ( fscanf ( fi,"%c", &c), c != '\n' )
+			while ( fscanf_s ( fi,"%c", &c, 1), c != '\n' )
 				;
 		}
 		
 		else
 		{
 			N++ ;
-			fscanf ( fi, "%*s %*s" ) ;
+			fscanf_s ( fi, "%*s %*s" ) ;
 		}
 	}
 	
@@ -1053,7 +1053,7 @@ int		Wallcount ( FILE *fi )
 	
 	add = ftell ( fi ) ;
 	
-	while ( fscanf ( fi, " %s ", s ) != EOF )
+	while ( fscanf_s ( fi, " %s ", s, sizeof(s) ) != EOF )
 	{
 		if ( *s == '*' )
 			break ;

--- a/Source/bl/blpcm.c
+++ b/Source/bl/blpcm.c
@@ -14,7 +14,7 @@
 //along with Foobar.If not, see < https://www.gnu.org/licenses/>.
 
 /*   binit.c   */
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <malloc.h>
@@ -39,11 +39,11 @@ void PCMdata(FILE *fi, char *dsn, PCM **pcm, int *Npcm, char *pcmiterate)
 	int		N, j;
 
 	PCMa = NULL;
-	sprintf(E, ERRFMT, dsn);
+	sprintf_s(E, sizeof(E), ERRFMT, dsn);
 
 	N = PCMcount(fi);
 
-	strcpy(s, "PCMdata --");
+	strcpy_s(s, SCHAR, "PCMdata --");
 
 	if (N > 0)
 	{
@@ -88,7 +88,7 @@ void PCMdata(FILE *fi, char *dsn, PCM **pcm, int *Npcm, char *pcmiterate)
 	}
 
 	PCMa = *pcm;
-	while (fscanf(fi, " %s ", s) != EOF)
+	while (fscanf_s(fi, " %s ", s, sizeof(s)) != EOF)
 	{
 		//printf( "<WAlldata> 1.... s=%s\n", s ) ;
 
@@ -97,7 +97,7 @@ void PCMdata(FILE *fi, char *dsn, PCM **pcm, int *Npcm, char *pcmiterate)
 
 		PCMa->name = stralloc(s);							// PCM名称
 
-		while (fscanf(fi, "%s", s), *s != ';')
+		while (fscanf_s(fi, "%s", s, sizeof(s)), *s != ';')
 		{
 			//printf ( "<Walldata> 2..... s=%s\n", s ) ;
 
@@ -288,8 +288,7 @@ void TableRead(CHARTABLE *ct)
 {
 	if (ct->filename != NULL)
 	{
-		ct->fp = fopen(ct->filename, "r");
-		if (ct->fp == NULL)
+		if (fopen_s(&(ct->fp), ct->filename, "r") != 0)
 			printf("<PCMdata> xxxx file not found %s xxxx\n", ct->filename);
 		else
 		{
@@ -297,7 +296,7 @@ void TableRead(CHARTABLE *ct)
 			char c;
 			int	 row;
 			row = 0;
-			while (fscanf(ct->fp, "%c", &c) != EOF)
+			while (fscanf_s(ct->fp, "%c", &c, 1) != EOF)
 			{
 				if (c == '\n')
 					row++;
@@ -310,7 +309,7 @@ void TableRead(CHARTABLE *ct)
 			if (ct->T == NULL || ct->Chara == NULL)
 				printf("<PCMdata> メモリの確保に失敗\n");
 			// 再度ファイルを開く
-			ct->fp = fopen(ct->filename, "r");
+			fopen_s(&ct->fp, ct->filename, "r");
 			int i;
 			int st = 0, tt = 0;
 			double spheat, prevheat, prevTemp;
@@ -323,7 +322,7 @@ void TableRead(CHARTABLE *ct)
 			for (i = 0; i < row; i++, T++, Char++)
 			{
 				// 温度の読み込み
-				fscanf(ct->fp, " %lf ", T);
+				fscanf_s(ct->fp, " %lf ", T);
 				// テーブルの下限温度
 				if (st == 0)
 				{
@@ -339,7 +338,7 @@ void TableRead(CHARTABLE *ct)
 				}
 				double dblTemp;
 				// 特性値の読み込み
-				fscanf(ct->fp, " %lf ", &dblTemp);
+				fscanf_s(ct->fp, " %lf ", &dblTemp);
 				*Char = dblTemp;
 				// 見かけの比熱の場合
 				if (ct->tabletype == 'h')
@@ -380,7 +379,7 @@ int		PCMcount(FILE *fi)
 
 	add = ftell(fi);
 
-	while (fscanf(fi, " %s ", s) != EOF)
+	while (fscanf_s(fi, " %s ", s, sizeof(s)) != EOF)
 	{
 		if (*s == '*')
 			break;

--- a/Source/bl/blrmdata.c
+++ b/Source/bl/blrmdata.c
@@ -14,7 +14,7 @@
 //along with Foobar.If not, see < https://www.gnu.org/licenses/>.
 
 /*  rmdata.c   */
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -125,19 +125,20 @@ void Roomdata (FILE *fi, char *errkey, EXSF *Exs, DFWL *dfwl,
 	Sch = Schdl->Sch;
 	vall = Schdl->val;
 
-	sprintf (Er, ERRFMT, errkey);
+	sprintf_s (Er, sizeof(Er), ERRFMT, errkey);
 	Rm-- ;
 	Sd-- ;
 
 	//sprintf(s, "No. 2") ;
 	//HeapCheck(s) ;
-	while (fscanf(fi, "%s", s), s[0] != '*')
+	while (fscanf_s(fi, "%s", s, sizeof(s)), s[0] != '*')
 	{
 		if ( DEBUG )
 			printf ( "%s\n", s ) ;
 		/*****************************/
 
-		strcat ( strcpy ( err, Er ), s ) ; 
+		strcpy_s ( err, sizeof(err), Er );
+		strcat_s ( err, sizeof(err), s ) ; 
 
 		i++ ;
 		Rm++ ;
@@ -152,7 +153,7 @@ void Roomdata (FILE *fi, char *errkey, EXSF *Exs, DFWL *dfwl,
 		{
 			if ( strcmp ( Rm->name, Rmchk->name ) == 0 )
 			{
-				sprintf ( RmnameEr, "Room=%s is already defined name", Rm->name ) ;
+				sprintf_s ( RmnameEr, sizeof(RmnameEr), "Room=%s is already defined name", Rm->name ) ;
 				Eprint ( "<Roomdata>", RmnameEr ) ;
 			}
 		}
@@ -163,7 +164,7 @@ void Roomdata (FILE *fi, char *errkey, EXSF *Exs, DFWL *dfwl,
 			if ( Rm->name != NULL && Rc->name != NULL
 				&& strcmp ( Rm->name, Rc->name ) == 0 )
 			{
-				sprintf ( ss, "<ROOM>  RoomName Already Defined  (%s)", Rm->name ) ;
+				sprintf_s ( ss, sizeof(ss), "<ROOM>  RoomName Already Defined  (%s)", Rm->name ) ;
 				Eprint ( "<Roomdata>", ss ) ;
 			}
 		}
@@ -179,12 +180,13 @@ void Roomdata (FILE *fi, char *errkey, EXSF *Exs, DFWL *dfwl,
 
 		//		Rm->metsc = Rm->closc = Rm->wvsc = -1;
 
-		while (fscanf(fi, "%s", s), s[0] != '#' && (s[0] != '*' || strlen(s) != 1))
+		while (fscanf_s(fi, "%s", s, sizeof(s)), s[0] != '#' && (s[0] != '*' || strlen(s) != 1))
 		{
 			if ( DEBUG )
 				printf("Roomdata  s=%s\n", s);
 
-			strcat(strcpy(err, Er), s); 
+			strcpy_s(err, sizeof(err), Er);
+			strcat_s(err, sizeof(err),s); 
 			if ( *s != '-' )
 			{
 				if (strcmp(s, "*s") == 0)
@@ -197,20 +199,20 @@ void Roomdata (FILE *fi, char *errkey, EXSF *Exs, DFWL *dfwl,
 				{
 					*st = '\0';
 					if ( *s == '(' )
-						sscanf(&s[1], "%[^)])", dnxrname);
+						sscanf_s(&s[1], "%[^)])", dnxrname, sizeof(dnxrname));
 					else
-						strcpy(dexsname, s);
+						strcpy_s(dexsname, sizeof(dexsname), s);
 				}
 				else if (strcmp(s, "Fij") == 0)
 				{
 					Rm->fij = 'F';
-					fscanf(fi, "%d", &N2);
+					fscanf_s(fi, "%d", &N2);
 					Rm->F = dcalloc(N2 * N2, " xxxxx Roomdata F");
 
 					ij=0;
-					while (fscanf(fi, "%s", ss), ss[0] != ';')
+					while (fscanf_s(fi, "%s", ss, sizeof(ss)), ss[0] != ';')
 					{
-						sscanf(ss, "%lf", &Rm->F[ij]);
+						sscanf_s(ss, "%lf", &Rm->F[ij]);
 						ij++ ;
 					}
 				}
@@ -229,7 +231,7 @@ void Roomdata (FILE *fi, char *errkey, EXSF *Exs, DFWL *dfwl,
 							Rm->VRM = atof(st+1);
 						else
 						{
-							sscanf ( st + 1, "%lf*%lf*%lf", &Wi, &H, &D ) ;
+							sscanf_s ( st + 1, "%lf*%lf*%lf", &Wi, &H, &D ) ;
 							Rm->VRM = Wi * H * D ;
 						}
 					}
@@ -309,7 +311,7 @@ void Roomdata (FILE *fi, char *errkey, EXSF *Exs, DFWL *dfwl,
 						}
 						if (Rm->PCM == NULL)
 						{
-							sprintf(Er, "Roomname=%s %sが見つかりません", Rm->name, Rm->PCMfurnname);
+							sprintf_s(Er, sizeof(Er), "Roomname=%s %sが見つかりません", Rm->name, Rm->PCMfurnname);
 							Eprint(Er, "<Roomdata>");
 							//if (NSTOP == 0)
 								preexit();
@@ -325,7 +327,7 @@ void Roomdata (FILE *fi, char *errkey, EXSF *Exs, DFWL *dfwl,
 					}
 					else
 					{
-						sprintf ( err, "Room=%s s=%s", Rm->name, s ) ;
+						sprintf_s ( err, sizeof(err), "Room=%s s=%s", Rm->name, s ) ;
 						Eprint ( "<Roomdata>", err ) ;
 					}
 				}
@@ -373,12 +375,13 @@ void Roomdata (FILE *fi, char *errkey, EXSF *Exs, DFWL *dfwl,
 				Sd->fnd[k] = 0 ;
 				/********************************/
 
-				while (fscanf(fi, "%s", s), s[0] != ';')
+				while (fscanf_s(fi, "%s", s, sizeof(s)), s[0] != ';')
 				{
 					if ( DEBUG )
 						printf("Roomdata1  s=%s\n", s);
 
-					strcat(strcpy(err, Er), s); 
+					strcpy_s(err, sizeof(err), Er);
+					strcat_s(err, sizeof(err), s); 
 
 					//printf ( "aaaaaa\n" ) ;
 
@@ -401,11 +404,11 @@ void Roomdata (FILE *fi, char *errkey, EXSF *Exs, DFWL *dfwl,
 						else if (strcmp(s, "*shd") == 0)
 							Sd->shdpri = 'p';
 
-						else if (( st = strchr(s, '*')) != NULL || sscanf(s, "%lf", &Sd->A) != 0 )
+						else if (( st = strchr(s, '*')) != NULL || sscanf_s(s, "%lf", &Sd->A) != 0 )
 						{
 							if ( Sd->A < 0.0 )
 							{
-								sscanf ( s, "%lf*%lf", &X, &Y ) ;
+								sscanf_s ( s, "%lf*%lf", &X, &Y ) ;
 								Sd->A = X * Y ;
 							}
 						}
@@ -417,14 +420,14 @@ void Roomdata (FILE *fi, char *errkey, EXSF *Exs, DFWL *dfwl,
 								Ercalloc(1, "<Roomdata> CTLIF" ) ;
 
 							// ifの最後まで読み込む
-							fscanf(fi, " (%[^)])", ss) ;
+							fscanf_s(fi, " (%[^)])", ss, sizeof(ss)) ;
 							Sd->dynamiccode = stralloc(ss) ;
 
 							// IF文の展開
 							//ctifdecode(s, Sd->ctlif, Simc, Ncompnt, Compnt, Nmpath, Mpath, Wd, Exsf, Schdl);
 
 							// Trueの時の窓の読み込み
-							fscanf(fi, "%s", s) ;
+							fscanf_s(fi, "%s", s, sizeof(s)) ;
 							Nwindow = Window->end ;
 							W = Window ;
 							for (j = 0; j < Nwindow; j++, W++)
@@ -439,7 +442,7 @@ void Roomdata (FILE *fi, char *errkey, EXSF *Exs, DFWL *dfwl,
 							}
 							if (j == Nwindow)
 							{
-								sprintf(err, "Room=%s <window> %s", Rm->name, stt);
+								sprintf_s(err, sizeof(err), "Room=%s <window> %s", Rm->name, stt);
 								Eprint("<Roomdata>", err);
 								//getch();
 								//if (NSTOP == 0)
@@ -501,7 +504,7 @@ void Roomdata (FILE *fi, char *errkey, EXSF *Exs, DFWL *dfwl,
 								}
 								if (j == Nwindow)
 								{
-									sprintf(err, "Room=%s <window> %s", Rm->name, stt);
+									sprintf_s(err, sizeof(err), "Room=%s <window> %s", Rm->name, stt);
 									Eprint("<Roomdata>", err);
 									//getch();
 									//if (NSTOP == 0)
@@ -539,7 +542,7 @@ void Roomdata (FILE *fi, char *errkey, EXSF *Exs, DFWL *dfwl,
 								}
 								if ( j == Nwall )
 								{
-									sprintf ( err, "Room=%s <wall> ble=%c %s Undefined in <WALL>", Rm->name, Sd->ble, s ) ;
+									sprintf_s ( err, sizeof(err), "Room=%s <wall> ble=%c %s Undefined in <WALL>", Rm->name, Sd->ble, s ) ;
 									Eprint ( "<Roomdata>", err ) ;
 									//getch();
 									//if (NSTOP == 0)
@@ -568,7 +571,7 @@ void Roomdata (FILE *fi, char *errkey, EXSF *Exs, DFWL *dfwl,
 							}
 							if ( j == Nexs )
 							{
-								sprintf ( err, "Room=%s <exsrf> %s\n", Rm->name, s ) ;
+								sprintf_s ( err, sizeof(err), "Room=%s <exsrf> %s\n", Rm->name, s ) ;
 								Eprint ( "<Roomdata>", err ) ;
 								//getch();
 								//if (NSTOP==0)
@@ -589,7 +592,7 @@ void Roomdata (FILE *fi, char *errkey, EXSF *Exs, DFWL *dfwl,
 							}
 							if ( j == Nsnbk ) 
 							{
-								sprintf ( err, "Room=%s <Snbrk> %s\n", Rm->name, s ) ;
+								sprintf_s ( err, sizeof(err), "Room=%s <Snbrk> %s\n", Rm->name, s ) ;
 								Eprint ( "<Roomdata>", err ) ;
 								//getch();
 								//if (NSTOP == 0)
@@ -669,7 +672,7 @@ void Roomdata (FILE *fi, char *errkey, EXSF *Exs, DFWL *dfwl,
 							Sd->tnxt = atoi(st + 1);
 						else
 						{
-							sprintf ( err, "Room=%s ble=%c s=%s\n",
+							sprintf_s ( err, sizeof(err), "Room=%s ble=%c s=%s\n",
 								Rm->name, Sd->ble, s ) ;
 							Eprint ( "<Roomdata>", err ) ;
 							//getch();
@@ -716,7 +719,7 @@ void Roomdata (FILE *fi, char *errkey, EXSF *Exs, DFWL *dfwl,
 						}
 						if ( j == Nexs )
 						{
-							sprintf ( err, "Room=%s  (%s)\n", Rm->name, dexsname ) ;
+							sprintf_s ( err, sizeof(err), "Room=%s  (%s)\n", Rm->name, dexsname ) ;
 							Eprint ( "<Roomdata>", err ) ;
 							//getch();
 							preexit();
@@ -876,7 +879,8 @@ void Roomdata (FILE *fi, char *errkey, EXSF *Exs, DFWL *dfwl,
 	{
 		if (( J = Sd->nxrm) >= 0)
 		{
-			strcat ( strcpy ( err, Er ), nxrmname[J] ) ;
+			strcpy_s ( err, sizeof(err), Er );
+			strcat_s ( err, sizeof(err), nxrmname[J] ) ;
 			Sd->nxrm = idroom ( nxrmname[J], Room, err ) ;
 			Sd->nextroom = Room + Sd->nxrm ;
 		}
@@ -1034,7 +1038,7 @@ void Roomdata (FILE *fi, char *errkey, EXSF *Exs, DFWL *dfwl,
 
 			if (rsd->nxn < 0 && rsd->mwtype == 'C')
 			{
-				sprintf(err, "%s    room=%s  xxx  (%s):  -%c\n", Er, (Room+rsd->rm)->name,
+				sprintf_s(err, sizeof(err), "%s    room=%s  xxx  (%s):  -%c\n", Er, (Room+rsd->rm)->name,
 					(Room+rsd->nxrm)->name, rsd->ble);
 				Eprint ( "<Roomdata>", err ) ;
 				//getch();
@@ -1511,7 +1515,7 @@ void Roomdata (FILE *fi, char *errkey, EXSF *Exs, DFWL *dfwl,
 	}
 
 	Rmvls->Emrk = scalloc ( Rmvls->Nroom, "<Roomdata> Emrk alloc" ) ;
-	strcpy ( Rmvls->Emrk, "" ) ;
+	strcpy_s ( Rmvls->Emrk, Rmvls->Nroom, "" ) ;
 
 	for ( i = 0; i < Nnxrm; i++ )
 		free ( nxrmname[i] ) ;
@@ -1546,7 +1550,7 @@ void Balloc (int N, RMSRF *Sd, WALL *Wall, MWALL **Mwall, int *Nmwall)
 	ssd = NULL ;
 	*Er = '\0' ;
 
-	sprintf (Er, ERRFMT, "(Balloc)");
+	sprintf_s (Er, sizeof(Er), ERRFMT, "(Balloc)");
 
 	mw = 0 ;
 	M = 0 ;
@@ -1691,7 +1695,7 @@ void Balloc (int N, RMSRF *Sd, WALL *Wall, MWALL **Mwall, int *Nmwall)
 	*Nmwall = Mw->end = mw;
 
 	char	hptest[SCHAR];
-	sprintf(hptest, "Main3");
+	sprintf_s(hptest, sizeof(hptest), "Main3");
 	HeapCheck(hptest);
 	ssd = Sd;
 	for (n = 0; n < N; n++, ssd++)
@@ -1911,11 +1915,11 @@ int		Roomcount ( FILE *fi )
 	N = 0 ;
 	ad = ftell ( fi ) ;
 
-	while ( fscanf ( fi, "%s", s ) != EOF && *s != '*' )
+	while ( fscanf_s ( fi, "%s", s, sizeof(s) ) != EOF && *s != '*' )
 	{
 		N++ ;
 
-		while ( fscanf ( fi, "%s", s ) != EOF )
+		while ( fscanf_s ( fi, "%s", s, sizeof(s) ) != EOF )
 		{
 			if ( strcmp ( s, "*" ) == 0 || strcmp ( s, "#" ) == 0 )
 				break ;
@@ -2018,12 +2022,12 @@ int		Rmsrfcount ( FILE *fi )
 	N = 0 ;
 	ad = ftell ( fi ) ;
 
-	while ( fscanf ( fi, "%s", s ) != EOF )
+	while ( fscanf_s ( fi, "%s", s, sizeof(s) ) != EOF )
 	{
 		if ( strcmp ( s, "*" ) == 0 || strcmp ( s, "#" ) == 0 )
 			break ;
 
-		while ( fscanf ( fi, "%s", s ) != EOF )
+		while ( fscanf_s ( fi, "%s", s, sizeof(s) ) != EOF )
 		{
 			if ( *s == '-' )
 				N++ ;
@@ -2074,7 +2078,7 @@ void	Rmsrfinit ( int N, RMSRF *S )
 		//		S->Rwall = 0.0 ;
 		S->mwside = 'i' ;
 		S->mwtype = 'I' ;
-		strcpy ( S->fnmrk, "" ) ;
+		strcpy_s ( S->fnmrk, sizeof(S->fnmrk), "" ) ;
 		S->alirsch = NULL ;
 		S->ffix_flg = '!' ;
 		S->fsol = NULL ;

--- a/Source/bl/blrmresid.c
+++ b/Source/bl/blrmresid.c
@@ -14,7 +14,7 @@
 //along with Foobar.If not, see < https://www.gnu.org/licenses/>.
 
 /*  rmresid.c   */
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include "MODEL.h" /*----higuchi 070918--*/
 #include "fesy.h"
@@ -38,25 +38,27 @@ void	Residata (FILE *fi, char *dsn, SCHDL *Schdl, ROOM *Room, int *pmvpri, SIMCO
 	
 	*s = *ss = *sss = *s4 = *err = *Er = '\0' ;
 
-	sprintf (Er, ERRFMT, dsn);
+	sprintf_s (Er, sizeof(Er), ERRFMT, dsn);
 	vall = Schdl->val ;
 	
-	while (fscanf(fi, "%s", s), *s != '*')
+	while (fscanf_s(fi, "%s", s, sizeof(s)), *s != '*')
 	{
-		strcat(strcpy(err, Er), s); 
+		strcpy_s(err, sizeof(err), Er);
+		strcat_s(err, sizeof(err), s); 
 		i = idroom ( s, Room, err ) ;
 		rm = Room + i ;
 		
-		while (fscanf(fi, "%s", s), s[0] != ';')
+		while (fscanf_s(fi, "%s", s, sizeof(s)), s[0] != ';')
 		{
-			strcat(strcpy(err, Er), s); 
+			strcpy_s(err, sizeof(err), Er);
+			strcat_s(err, sizeof(err), s); 
 			ce = strchr(s, ';');
 			st = strchr(s, '=');
 			*st = '\0';
 			
 			if (strcmp(s, "H") == 0)
 			{
-				sscanf(st+1, "(%lf,%[^,],%[^)])", &rm->Nhm, ss, sss);
+				sscanf_s(st+1, "(%lf,%[^,],%[^)])", &rm->Nhm, ss, sizeof(ss), sss, sizeof(sss));
 				//rm->hmnsc = idsch(ss, Sch, err);
 
 				if (( k = idsch(ss, Schdl->Sch, NULL )) >= 0 )
@@ -73,7 +75,7 @@ void	Residata (FILE *fi, char *dsn, SCHDL *Schdl, ROOM *Room, int *pmvpri, SIMCO
 			}
 			else if (strcmp(s, "comfrt") == 0)
 			{
-				sscanf(st+1, "(%[^,],%[^,],%[^)])", ss, sss, s4);
+				sscanf_s(st+1, "(%[^,],%[^,],%[^)])", ss, sizeof(ss), sss, sizeof(sss), s4, sizeof(s4));
 				//rm->metsc = idsch(ss, Sch, err);
 
 				if (( k = idsch(ss, Schdl->Sch, NULL )) >= 0 )
@@ -101,7 +103,7 @@ void	Residata (FILE *fi, char *dsn, SCHDL *Schdl, ROOM *Room, int *pmvpri, SIMCO
 			}
 			else
 			{
-				sprintf(err, "Room=%s  %s", rm->name, s );
+				sprintf_s(err, sizeof(err), "Room=%s  %s", rm->name, s );
 				Eprint ( "<Residata>", s ) ;
 			}
 			
@@ -125,15 +127,16 @@ void	Appldata (FILE *fi, char *dsn, SCHDL *Schdl, ROOM *Room, SIMCONTL *Simc)
 	*s = *ss = *err = *Er = '\0' ;
 	vall = Schdl->val ;
 
-	sprintf (Er, ERRFMT, dsn);
+	sprintf_s (Er, sizeof(Er), ERRFMT, dsn);
 	
-	while (fscanf(fi, "%s", s), s[0] != '*')
+	while (fscanf_s(fi, "%s", s, sizeof(s)), s[0] != '*')
 	{
-		strcat(strcpy(err, Er), s); 
+		strcpy_s(err, sizeof(err), Er);
+		strcat_s(err, sizeof(err), s); 
 		i = idroom(s, Room, err);
 		rm = Room + i ;
 		
-		while (fscanf(fi, "%s", s), s[0] != ';')
+		while (fscanf_s(fi, "%s", s, sizeof(s)), s[0] != ';')
 		{
 			ce = strchr(s, ';');
 			st = strchr(s, '=');
@@ -141,7 +144,7 @@ void	Appldata (FILE *fi, char *dsn, SCHDL *Schdl, ROOM *Room, SIMCONTL *Simc)
 			
 			if (strcmp(s, "L") == 0)
             {
-				sscanf(st+1, "(%lf,%c,%[^)])", &rm->Light, &rm->Ltyp, ss); 
+				sscanf_s(st+1, "(%lf,%c,%[^)])", &rm->Light, &rm->Ltyp, 1, ss, sizeof(ss)); 
 
 				if (( k = idsch ( ss, Schdl->Sch, NULL )) >= 0 )
 					rm->Lightsch = &vall[k] ;
@@ -152,7 +155,7 @@ void	Appldata (FILE *fi, char *dsn, SCHDL *Schdl, ROOM *Room, SIMCONTL *Simc)
 			}
 			else if (strcmp(s, "As") == 0)
             {
-				sscanf(st+1, "(%lf,%lf,%[^)])", &rm->Apsc, &rm->Apsr, ss);
+				sscanf_s(st+1, "(%lf,%lf,%[^)])", &rm->Apsc, &rm->Apsr, ss, sizeof(ss));
 
 				if (( k = idsch ( ss, Schdl->Sch, NULL )) >= 0 )
 					rm->Assch = &vall[k] ;
@@ -163,7 +166,7 @@ void	Appldata (FILE *fi, char *dsn, SCHDL *Schdl, ROOM *Room, SIMCONTL *Simc)
 			}
 			else if (strcmp(s, "Al") == 0)
             {
-				sscanf(st+1, "(%lf,%[^)])", &rm->Apl, ss);
+				sscanf_s(st+1, "(%lf,%[^)])", &rm->Apl, ss, sizeof(ss));
 
 				if (( k = idsch ( ss, Schdl->Sch, NULL )) >= 0 )
 					rm->Alsch = &vall[k] ;
@@ -174,7 +177,7 @@ void	Appldata (FILE *fi, char *dsn, SCHDL *Schdl, ROOM *Room, SIMCONTL *Simc)
 			}
 			else if (strcmp(s, "AE") == 0)
             {
-				sscanf(st+1, "(%lf,%[^)])", &rm->AE, ss);
+				sscanf_s(st+1, "(%lf,%[^)])", &rm->AE, ss, sizeof(ss));
 
 				if (( k = idsch ( ss, Schdl->Sch, NULL )) >= 0 )
 					rm->AEsch = &vall[k] ;
@@ -183,7 +186,7 @@ void	Appldata (FILE *fi, char *dsn, SCHDL *Schdl, ROOM *Room, SIMCONTL *Simc)
 			}
 			else if (strcmp(s, "AG") == 0)
             {
-				sscanf(st+1, "(%lf,%[^)])", &rm->AG, ss);
+				sscanf_s(st+1, "(%lf,%[^)])", &rm->AG, ss, sizeof(ss));
 
 				if (( k = idsch ( ss, Schdl->Sch, NULL )) >= 0 )
 					rm->AGsch = &vall[k] ;
@@ -192,7 +195,7 @@ void	Appldata (FILE *fi, char *dsn, SCHDL *Schdl, ROOM *Room, SIMCONTL *Simc)
 			}
 			else
 			{
-				sprintf ( err, "Room=%s  %s", rm->name, s ) ;
+				sprintf_s ( err, sizeof(err), "Room=%s  %s", rm->name, s ) ;
 				Eprint ( "<Appldata>", err ) ;
 			}
 			

--- a/Source/bl/blrmschd.c
+++ b/Source/bl/blrmschd.c
@@ -15,7 +15,7 @@
 
 /*   rmschd.c      */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include "common.h"
 #include "MODEL.h" /*----higuchi 070918--*/
 #include "fesy.h"
@@ -108,7 +108,7 @@ void Qischdlr(int Nroom, ROOM* Room)
 
 				if (wk < 0 || wk > 8)
 				{
-					sprintf(s, "Room=%s wk=%d", Room->name, wk);
+					sprintf_s(s, sizeof(s), "Room=%s wk=%d", Room->name, wk);
 					Eprint("<Qischdlr>", s);
 				}
 

--- a/Source/bl/blrmvent.c
+++ b/Source/bl/blrmvent.c
@@ -14,7 +14,7 @@
 //along with Foobar.If not, see < https://www.gnu.org/licenses/>.
 
 /* rmvent.c  */
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include "MODEL.h" /*----higuchi 070918--*/
 #include "fesy.h"
@@ -38,14 +38,15 @@ void Ventdata(FILE *fi, char *dsn, SCHDL *Schdl, ROOM *Room, SIMCONTL *Simc )
 	
 	vall = Schdl->val ;
 
-	sprintf (E, ERRFMT, dsn);
-	while ( fscanf ( fi, " %s ", name1 ), *name1 != '*' )
+	sprintf_s (E, sizeof(E), ERRFMT, dsn);
+	while ( fscanf_s ( fi, " %s ", name1, sizeof(name1) ), *name1 != '*' )
 	{
-		strcat ( strcpy ( err, E ), name1 ) ;
+		strcpy_s ( err, sizeof(err), E );
+		strcat_s ( err, sizeof(err), name1 ) ;
 		i = idroom ( name1, Room, err ) ;
 		Rm = Room + i ;
 		
-		fscanf ( fi, " %s ", s ) ;
+		fscanf_s ( fi, " %s ", s, sizeof(s) ) ;
 		if (( st = strchr ( s, '=' )) != 0 )
 		{
 			while ( s )
@@ -53,7 +54,7 @@ void Ventdata(FILE *fi, char *dsn, SCHDL *Schdl, ROOM *Room, SIMCONTL *Simc )
 				*st = '\0';
 				if ( strcmp( s, "Vent") == 0 )
 				{
-					sscanf ( st + 1, "(%lf,%[^)])", &val, ss ) ;
+					sscanf_s ( st + 1, "(%lf,%[^)])", &val, ss, sizeof(ss) ) ;
 					Rm->Gve = val;
 
 					if (( k = idsch(ss, Schdl->Sch, NULL )) >= 0 )
@@ -69,7 +70,7 @@ void Ventdata(FILE *fi, char *dsn, SCHDL *Schdl, ROOM *Room, SIMCONTL *Simc )
 				}
 				else if (strcmp(s, "Inf") == 0)
 				{
-					sscanf(st+1, "(%lf,%[^)])", &val, ss);
+					sscanf_s(st+1, "(%lf,%[^)])", &val, ss, sizeof(ss));
 					Rm->Gvi = val;
 
 					if (( k = idsch(ss, Schdl->Sch, NULL )) >= 0 )
@@ -85,13 +86,13 @@ void Ventdata(FILE *fi, char *dsn, SCHDL *Schdl, ROOM *Room, SIMCONTL *Simc )
 				}
 				else
 				{
-					sprintf ( err, "Room=%s  %s", Rm->name, s ) ;
+					sprintf_s ( err, sizeof(err), "Room=%s  %s", Rm->name, s ) ;
 					Eprint ( "<Ventedata>", err ) ;
 				}
 				
 				if ( strchr ( st + 1, ';') != 0)
 					break;
-				fscanf ( fi, " %s ", s ) ;
+				fscanf_s ( fi, " %s ", s, sizeof(s) ) ;
 				if ( *s == ';')
 					break ;
 				st = strchr ( s, '=' ) ;
@@ -100,17 +101,19 @@ void Ventdata(FILE *fi, char *dsn, SCHDL *Schdl, ROOM *Room, SIMCONTL *Simc )
 		else
 		{
 			c = *s ; 
-			fscanf ( fi, " %s v= %s ;", name2, s ) ;
+			fscanf_s ( fi, " %s v= %s ;", name2, sizeof(name2), s, sizeof(s) ) ;
 			if ( c == ';' ) break ;
 			/******************
 			printf("Aichdata  %s (%c)  %s\n", name1, c, name2);
 			************/
-			strcat ( strcpy ( err, E ), name2 ) ;
+			strcpy_s ( err, sizeof(err), E );
+			strcat_s ( err, sizeof(err), name2 ) ;
 			j = idroom ( name2, Room, err ) ;
 			
 			if (( ce = strchr ( s, ';' )) != 0 )
 				*ce = '\0' ;
-			strcat ( strcpy ( err, E ), s ) ;
+			strcpy_s ( err, sizeof(err), E );
+			strcat_s ( err, sizeof(err), s ) ;
 			v = idsch ( s, Schdl->Sch, err ) ;
 
 			switch ( c )

--- a/Source/bl/blroom.c
+++ b/Source/bl/blroom.c
@@ -14,7 +14,7 @@
 //along with Foobar.If not, see < https://www.gnu.org/licenses/>.
 
 /*  room.c       */
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdlib.h>
 #include "common.h"
 #include "MODEL.h" /*----higuchi 070918--*/
@@ -143,7 +143,7 @@ void	RMcf(ROOM *Room)
 	sprintf ( E, "Room=%s  <Rmcf>", Room->name ) ;
         printf("%s, %d, %f",E,N,XA) ;
 	----*/
-	sprintf(E, "<RMcf> name=%s", Room->name);
+	sprintf_s(E, sizeof(E), "<RMcf> name=%s", Room->name);
 	matinv(XA, N, N, E );
        
         /*--

--- a/Source/bl/blrzone.c
+++ b/Source/bl/blrzone.c
@@ -14,7 +14,7 @@
 //along with Foobar.If not, see < https://www.gnu.org/licenses/>.
 
 /* rzone.c */
-#define _CRT_SECURE_NO_WARNINGS
+
 #include "fesy.h"
 #include "fnesy.h"
 #include "fnfio.h"
@@ -28,14 +28,14 @@ void	Rzonedata(FILE *fi, char *dsn, int Nroom, ROOM *Room, int *Nrzone, RZONE *R
 	char	s[SCHAR];
 	ROOM	*Rm ;
 	
-	while ( fscanf ( fi, "%s", s ), *s != '*')
+	while ( fscanf_s(fi, "%s", s, sizeof(s)), *s != '*')
 	{    
-		fscanf ( fi, "%s", s ) ;
+		fscanf_s(fi, "%s", s, sizeof(s)) ;
 		Rzone->name = stralloc(s);
 		Rzone->Nroom = 0;
 		Rzone->Afloor = 0.0;
 		
-		while ( fscanf ( fi, "%s", s), *s != ';')
+		while ( fscanf_s ( fi, "%s", s, sizeof(s)), *s != ';')
 		{
 			if (( i = idroom ( s, Room, NULL )) < Nroom )
 			{

--- a/Source/bl/blwall.c
+++ b/Source/bl/blwall.c
@@ -14,7 +14,7 @@
 //along with Foobar.If not, see < https://www.gnu.org/licenses/>.
 
 /*   bl_wall.c   */
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -106,7 +106,7 @@ void Walli(int Nbm, BMLST *W, WALL *Wl, PCM *pcm, int Npcm)
 
 		if (k == Nbm)
 		{
-			sprintf(E, "%s", Welm->code);
+			sprintf_s(E, sizeof(E), "%s", Welm->code);
 			Eprint("<Walli>", E);
 		}
 

--- a/Source/e79.c
+++ b/Source/e79.c
@@ -25,7 +25,6 @@
 #define TEST 0
 /*******************/
 
-#define _CRT_SECURE_NO_WARNINGS
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -309,7 +308,7 @@ int main(int Narg, char **File)
 
 	/* ------------------------------------------------------ */
 
-	sprintf(Err, ERRFMT, "(main)");
+	sprintf_s(Err, sizeof(Err), ERRFMT, "(main)");
 	Psyint();
 
 	//for(i=0 ;i<Narg ; i++){
@@ -319,7 +318,7 @@ int main(int Narg, char **File)
 	if (Narg == 1)
 	{
 		printf("=== (main)  Input data file name ? \n");
-		scanf("%s", s);
+		scanf_s("%s", s, sizeof(s));
 		File[1] = s;
 		printf(" data file = %s\n", s);
 	}
@@ -327,21 +326,20 @@ int main(int Narg, char **File)
 	//printf("Narg=%d file=%s\n",Narg,File[1]);
 	Ifile = NULL;
 	Ifile = stralloc(File[1]);
-	strcpy(s, Ifile);
-
-	// 入力されたパスが"で始まる場合に除去する
-	if (Ifile[0] == '"')
-		sscanf(Ifile, "\"%~[\"]\"", s);
+	strcpy_s(s, sizeof(s), Ifile);
 
 	if ((st = strrchr(Ifile, '\\')) != NULL)
 		*st = '\0';
 
 	// 一時吐き出しファイル"*.ewk"のパス変更
-	strcat(strcpy(Ipath, Ifile), "\\");
+	strcpy_s(Ipath, sizeof(Ipath), Ifile);
+	strcat_s(Ipath, sizeof(Ipath), "\\");
 
 	eesprera(s, Ipath);
 	char EWKFile[SCHAR];
-	strcpy(EWKFile, STRCUT(s, '.'));
+	char* s_cut = STRCUT(s, '.');
+	strcpy_s(EWKFile, sizeof(EWKFile), s_cut);
+	free(s_cut);	//STRCUTで生成したメモリの開放
 
 	eespre("bdata0.ewk", EWKFile, &key);
 
@@ -378,21 +376,24 @@ int main(int Narg, char **File)
 	}
 
 	/////////////////////////////////
-	sprintf(hptest, "Main1");
+	sprintf_s(hptest, sizeof(hptest), "Main1");
 	HeapCheck(hptest);
 	/////////////////////////////////
 
 	if (bdpn != 0){
 
-		strcpy(RET, STRCUT(s, '.'));
+		char* s_cut = STRCUT(s, '.');
+		strcpy_s(RET, sizeof(RET), s_cut);
+		free(s_cut);	//STRCUTで生成したメモリの開放
+
 		//printf ( "SSSSS1\n" ) ;
-		strcpy(RET1, RET);
+		strcpy_s(RET1, sizeof(RET1), RET);
 		//printf ( "SSSSS2\n" ) ;
-		strcpy(RET3, RET);
+		strcpy_s(RET3, sizeof(RET3), RET);
 		//printf ( "SSSSS3\n" ) ;
-		strcpy(RET14, RET);
+		strcpy_s(RET14, sizeof(RET14), RET);
 		//printf ( "SSSSS4\n" ) ;
-		strcpy(RET15, RET);
+		strcpy_s(RET15, sizeof(RET15), RET);
 
 		//printf ( "SSSSS5\n" ) ;
 
@@ -421,29 +422,29 @@ int main(int Narg, char **File)
 		strcat(RET13,"_OPLP") ;
 		strcat(RET16,"_SHAD") ;
 #endif    
-		strcat(RET, "_shadow.gchi");
+		strcat_s(RET, sizeof(RET), "_shadow.gchi");
 		//printf ( "SSSSS6\n" ) ;
-		strcat(RET1, "_I.gchi");
+		strcat_s(RET1, sizeof(RET1), "_I.gchi");
 		//printf ( "SSSSS7\n" ) ;
-		strcat(RET3, "_ffactor.gchi");
+		strcat_s(RET3, sizeof(RET3), "_ffactor.gchi");
 		//printf ( "SSSSS8\n" ) ;
-		strcat(RET14, "_lwr.gchi");
+		strcat_s(RET14, sizeof(RET14), "_lwr.gchi");
 		//printf ( "SSSSS9\n" ) ;
 
-		if ((fp1 = fopen(RET, "w")) == NULL){
+		if (fopen_s(&fp1, RET, "w") != 0){
 			printf("File not open _shadow.gchi\n");
 			exit(1);
 		}
-		if ((fp2 = fopen(RET1, "w")) == NULL){
+		if (fopen_s(&fp2, RET1, "w") != 0){
 			printf("File not open _I.gchi\n");
 			exit(1);
 		}
 
-		if ((fp3 = fopen(RET14, "w")) == NULL){
+		if (fopen_s(&fp3, RET14, "w") != 0){
 			printf("File not open _lwr.gchi\n");
 			exit(1);
 		}
-		if ((fp4 = fopen(RET3, "w")) == NULL){
+		if (fopen_s(&fp4, RET3, "w") != 0){
 			printf("File not open _ffactor.gchi\n");
 			exit(1);
 		}
@@ -618,7 +619,7 @@ int main(int Narg, char **File)
 			Npelm, Ncmpalloc, Ncompnt, Nelout, Nelin);
 	}
 	/////////////////////////////////
-	sprintf(hptest, "Main2");
+	sprintf_s(hptest, sizeof(hptest), "Main2");
 	HeapCheck(hptest);
 	/////////////////////////////////
 
@@ -645,7 +646,7 @@ int main(int Narg, char **File)
 	dprballoc(Rmvls.Mw, Rmvls.Sd);
 
 	/////////////////////////////////
-	sprintf(hptest, "Main3");
+	sprintf_s(hptest, sizeof(hptest), "Main3");
 	HeapCheck(hptest);
 	/////////////////////////////////
 
@@ -943,7 +944,7 @@ int main(int Narg, char **File)
 					}
 				}
 				/////////////////////////////////
-				sprintf(hptest, "Main KAGE-SUN");
+				sprintf_s(hptest, sizeof(hptest), "Main KAGE-SUN");
 				HeapCheck(hptest);
 				/////////////////////////////////
 				//printf("H=%5.2f\n",Daytm.time) ;
@@ -1055,7 +1056,7 @@ int main(int Narg, char **File)
 				}
 
 				/////////////////////////////////
-				sprintf(hptest, "Main eeroomcf");
+				sprintf_s(hptest, sizeof(hptest), "Main eeroomcf");
 				HeapCheck(hptest);
 				/////////////////////////////////
 
@@ -1100,7 +1101,7 @@ int main(int Narg, char **File)
 				for (i = 0; i < LOOP_MAX; i++)
 				{
 					char	s[256];
-					sprintf(s, "Loop Start %d", i);
+					sprintf_s(s, sizeof(s), "Loop Start %d", i);
 					HeapCheck(s);
 
 					if (i == 0)
@@ -1671,7 +1672,7 @@ void P_MENNinit(P_MENN *pm, int N)
 	for (i = 0; i < N; i++, pm++)
 	{
 		pm->Nopw = 0;
-		pm->opname = NULL;
+		strcpy_s(pm->opname, OPNAME_SZ, "");
 		matinit(pm->rgb, 3);
 		matinit(pm->faiwall, pmax);
 		pm->wd = pm->exs = 0;

--- a/Source/ee/eebslib.c
+++ b/Source/ee/eebslib.c
@@ -1,6 +1,6 @@
 ﻿/*    bslib.c            */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -32,7 +32,7 @@ void Exsfdata (FILE *fi, char *dsn, EXSFS *Exsf, SCHDL *Schdl, SIMCONTL *Simc )
 //	EXSF	*e ;
 	char	Err[SCHAR+128];
 	
-	strcpy ( s, dsn ) ;
+	strcpy_s ( s, sizeof(s), dsn ) ;
 	Nd = imax ( ExsfCount ( fi ), 1 ) ;
 
 	vall = Schdl->val ;
@@ -40,7 +40,7 @@ void Exsfdata (FILE *fi, char *dsn, EXSFS *Exsf, SCHDL *Schdl, SIMCONTL *Simc )
 	/****************/
 	if ( Nd > 0 )
 	{
-		sprintf(s, "%lf", ALO);
+		sprintf_s(s, sizeof(s), "%lf", ALO);
 		Exsf->alosch = envptr(s,Simc,0,NULL,NULL,NULL) ;
 		Exsf->alotype = 'F' ;
 		Exsf->Exs = ( EXSF * ) malloc (( Nd + 1 ) * sizeof ( EXSF )) ;
@@ -59,7 +59,7 @@ void Exsfdata (FILE *fi, char *dsn, EXSFS *Exsf, SCHDL *Schdl, SIMCONTL *Simc )
 //	sprintf (E, ERRFMT, dsn);
 	ex = Exsf->Exs - 1 ;
 	
-	while (fscanf(fi, "%s", s), s[0] != '*')
+	while (fscanf_s(fi, "%s", s, sizeof(s)), s[0] != '*')
 	{
 		//printf ( "s=%s\n", s ) ;
 
@@ -87,7 +87,7 @@ void Exsfdata (FILE *fi, char *dsn, EXSFS *Exsf, SCHDL *Schdl, SIMCONTL *Simc )
 
 			if (dfrg<0. || dfrg>1.0)
 			{
-				sprintf(Err, "%s の設置値が不適切です", s);
+				sprintf_s(Err, sizeof(Err), "%s の設置値が不適切です", s);
 				preexit();
 			}
 		}
@@ -143,22 +143,22 @@ void Exsfdata (FILE *fi, char *dsn, EXSFS *Exsf, SCHDL *Schdl, SIMCONTL *Simc )
 			//}
 		}
 		
-		while (fscanf(fi, " %s ", s), s[0] != ';')
+		while (fscanf_s(fi, " %s ", s, sizeof(s)), s[0] != ';')
 		{ 
 			//printf ( "s=%s\n", s ) ;
 
 			if ( strncmp ( s, "a=", 2 ) == 0 )
 			{
-				if (sscanf(&s[2], "%lf", &dt) != 0)
+				if (sscanf_s(&s[2], "%lf", &dt) != 0)
 					ex->Wa =dt;
 				else
 				{
 					if (strchr(s, '+'))
-						Nd = sscanf(&s[2], "%[^+]%lf", ename, &dt);
+						Nd = sscanf_s(&s[2], "%[^+]%lf", ename, sizeof(ename), &dt);
 					else if (strchr(s, '-'))
-						Nd = sscanf(&s[2], "%[^-]%lf", ename, &dt); 
+						Nd = sscanf_s(&s[2], "%[^-]%lf", ename, sizeof(ename), &dt); 
 					else
-						Nd = sscanf(&s[2], "%s", ename);
+						Nd = sscanf_s(&s[2], "%s", ename, sizeof(ename));
 					
 					exj = Exsf->Exs ;
 					for (j=0; j<i+1; j++, exj++)
@@ -438,7 +438,7 @@ int	ExsfCount ( FILE *fi )
 	
 	ad = ftell ( fi ) ;
 	
-	while ( fscanf ( fi, " %s ", s ), s[0] != '*' )
+	while ( fscanf_s ( fi, " %s ", s, sizeof(s) ), s[0] != '*' )
 	{
 		/***********************
 		if ( strncmp ( s, "r=", 2 ) == 0 )

--- a/Source/ee/eecmpdat_s.c
+++ b/Source/ee/eecmpdat_s.c
@@ -17,7 +17,7 @@
 
 /*   システム要素の入力 */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -188,7 +188,7 @@ void Compodata(FILE *f, char *errkey, RMVLS *Rmvls, EQCAT *Eqcat,
 
 	if ( ID == 0 )
 	{
-		while (fscanf(f, "%s", s), *s != '*')
+		while (fscanf_s(f, "%s", s, sizeof(s)), *s != '*')
 		{
 			//Ncrm = Compnt - cmp ;
 			cio=' '; 
@@ -197,15 +197,15 @@ void Compodata(FILE *f, char *errkey, RMVLS *Rmvls, EQCAT *Eqcat,
 			if ( *s == '(' )
 			{
 				if ( strlen ( s ) == 1 )
-					fscanf ( f, "%s", s ) ;
+					fscanf_s ( f, "%s", s, sizeof(s) ) ;
 				else
-					sscanf ( s, "(%s", s ) ;
+					sscanf_s ( s, "(%s", s, sizeof(s) ) ;
 
 				Crm = NULL ;
 				Compnt->name = stralloc ( s ) ;
 				Compnt++ ;
 
-				fscanf ( f, "%s", s ) ;
+				fscanf_s ( f, "%s", s, sizeof(s) ) ;
 
 				if (( st = strchr ( s, ')' )) != NULL )
 				{
@@ -240,7 +240,7 @@ void Compodata(FILE *f, char *errkey, RMVLS *Rmvls, EQCAT *Eqcat,
 				}
 			}
 
-			while (fscanf(f, "%s", s), *s != ';')
+			while (fscanf_s(f, "%s", s, sizeof(s)), *s != ';')
 			{
 				if (*s == '-')
 				{ 
@@ -468,7 +468,7 @@ void Compodata(FILE *f, char *errkey, RMVLS *Rmvls, EQCAT *Eqcat,
 
 					case 'R':
 						Compnt->roomname = stralloc(s) ;
-						fscanf ( f, "%lf", &Compnt->eqpeff ) ;
+						fscanf_s ( f, "%lf", &Compnt->eqpeff ) ;
 						break ;
 
 					case 's':
@@ -479,12 +479,12 @@ void Compodata(FILE *f, char *errkey, RMVLS *Rmvls, EQCAT *Eqcat,
 						Compnt->omparm = stralloc(s) ;
 						break ;
 					case 'S': case 'V':
-						strcat(s, "  ");
+						strcat_s(s, sizeof(s), "  ");
 						st = s + strlen(s);
 
-						fscanf(f, "%[^*]*", st); 
+						fscanf_s(f, "%[^*]*", st, sizeof(st)); 
 
-						strcat(s, " *"); 
+						strcat_s(s, sizeof(s), " *"); 
 
 						Compnt->tparm = stralloc(s);
 
@@ -493,9 +493,9 @@ void Compodata(FILE *f, char *errkey, RMVLS *Rmvls, EQCAT *Eqcat,
 					case 'T':
 						if (*s == '(')
 						{	  
-							strcat(s, " ");
+							strcat_s(s, sizeof(s), " ");
 							st = s + strlen(s);
-							fscanf(f, "%[^)])", st);
+							fscanf_s(f, "%[^)])", st, sizeof(st));
 							Compnt->tparm = stralloc(s);
 						}
 						else
@@ -538,8 +538,8 @@ void Compodata(FILE *f, char *errkey, RMVLS *Rmvls, EQCAT *Eqcat,
 		{
 			if (strcmp(cm->eqptype, DIVGAIR_TYPE) == 0)
 			{
-				strcpy ( s, cm->name ) ;
-				strcat ( s, ".x" ) ;
+				strcpy_s ( s, sizeof(s), cm->name ) ;
+				strcat_s ( s, sizeof(s), ".x" ) ;
 				Compnt->name = stralloc ( s ) ;
 
 				/**********************
@@ -558,8 +558,8 @@ void Compodata(FILE *f, char *errkey, RMVLS *Rmvls, EQCAT *Eqcat,
 			}
 			else if (strcmp(cm->eqptype, CVRGAIR_TYPE) == 0)
 			{
-				strcpy ( s, cm->name ) ;
-				strcat ( s, ".x" ) ;
+				strcpy_s ( s, sizeof(s), cm->name ) ;
+				strcat_s ( s, sizeof(s), ".x" ) ;
 				Compnt->name = stralloc ( s ) ;
 
 				/*********************
@@ -1051,14 +1051,14 @@ void Compodata(FILE *f, char *errkey, RMVLS *Rmvls, EQCAT *Eqcat,
 		N = 0 ;
 		ad = ftell ( fi ) ;
 
-		while ( fscanf ( fi, "%s", s ) != EOF )
+		while ( fscanf_s ( fi, "%s", s, sizeof(s) ) != EOF )
 		{
 			//printf ( "%s\n", s ) ;
 			if ( strcmp ( s, ";" ) == 0 )
 			{
 				N++ ;
 
-				fscanf ( fi, "%s", s ) ;
+				fscanf_s ( fi, "%s", s, sizeof(s) ) ;
 
 				if ( *s == '*' )
 					break ;

--- a/Source/ee/eefiles.c
+++ b/Source/ee/eefiles.c
@@ -14,7 +14,7 @@
 //along with Foobar.If not, see < https://www.gnu.org/licenses/>.
 
 /*  eesfiles.c  */
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include <stdlib.h>
 #include "common.h"
@@ -31,25 +31,25 @@ void eeflopen(SIMCONTL *Simc, int Nflout, FLOUT *Flout)
 	FLOUT *fl;
 	char  Fname[SCHAR], Err[SCHAR] ; 
 	
-	sprintf(Err, ERRFMT, "(eeflopen)");
+	sprintf_s(Err, sizeof(Err), ERRFMT, "(eeflopen)");
 	
 	if (Simc->wdtype == 'H')
 	{
-		if ((Simc->fwdata = fopen(Simc->wfname, "r")) == 0)
+		if (fopen_s(&(Simc->fwdata), Simc->wfname, "r") != 0)
 		{
 			Eprint ( "<eeflopen>", Simc->wfname ) ;
             //getch() ;
 			preexit ( ) ;
 			exit(EXIT_WFILE);
 		}
-		if ((Simc->fwdata2 = fopen(Simc->wfname, "r")) == 0)
+		if (fopen_s(&(Simc->fwdata2), Simc->wfname, "r") != 0)
 		{
 			Eprint ( "<eeflopen>", Simc->wfname ) ;
             //getch() ;
 			preexit ( ) ;
 			exit(EXIT_WFILE);
 		}
-		if ((Simc->ftsupw = fopen("supw.efl", "r")) == 0)
+		if (fopen_s(&(Simc->ftsupw), "supw.efl", "r") != 0)
 		{
 			Eprint ( "<eeflopen>", "supw.efl" ) ;
             //getch() ;
@@ -63,8 +63,10 @@ void eeflopen(SIMCONTL *Simc, int Nflout, FLOUT *Flout)
 
 	for (fl = Flout; fl < Flout+Nflout; fl++)
 	{
-		strcat(strcpy(Fname, Simc->ofname), fl->idn);      
-		fl->f = fopen(strcat(Fname, ".es"), "w");
+		strcpy_s(Fname, sizeof(Fname), Simc->ofname);
+		strcat_s(Fname, sizeof(Fname), fl->idn);
+		strcat_s(Fname, sizeof(Fname), ".es");
+		fopen_s(&(fl->f), Fname, "w");
 	}
 }
 /* ----------------------------------------------------- */

--- a/Source/ee/eegndata.c
+++ b/Source/ee/eegndata.c
@@ -15,7 +15,7 @@
 
 /*    ee_gndata.c      */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #define FLDELIM  '/'
 #include <stdio.h>
 #include <stdlib.h>
@@ -45,7 +45,7 @@ void Gdata (FILE *fi, char *dsn, char *File, char **wfname, char **ofname,
 	
 	*wfname = NULL;
 	
-	sprintf (E, ERRFMT, dsn);
+	sprintf_s (E, sizeof(E), ERRFMT, dsn);
 	
 	*ofname = stralloc( File);
 
@@ -59,17 +59,13 @@ void Gdata (FILE *fi, char *dsn, char *File, char **wfname, char **ofname,
 	if ((st = strrchr(*ofname, '.')) != NULL)
 		*st = '\0';
 	
-	while (fscanf(fi, "%s", s), s[0] != '*')
+	while (fscanf_s(fi, "%s", s, sizeof(s)), s[0] != '*')
 	{ 
 		if (strcmp(s, "FILE") == 0)
 		{ 
-		/********
-		strcpy(ofname, File);
-		if ((st = strrchr(ofname, '.')) != NULL)
-		*st = '\0';
-			*******/
+			// ex) "   FILE   w=wd/6_Tokyo2010_watanabe.has -skyrd ;"
 			
-			while (fscanf(fi, "%s", s), s[0] != ';')
+			while (fscanf_s(fi, "%s", s, sizeof(s)), s[0] != ';')
 			{
 				if ((ce=strchr(s, ';')) != 0)
 					*ce = '\0';
@@ -84,12 +80,12 @@ void Gdata (FILE *fi, char *dsn, char *File, char **wfname, char **ofname,
 					*st = '\0';
 					if (strcmp(s, "w") == 0)
 					{
-						sscanf(st+1, "%s", dd);
+						sscanf_s(st+1, "%s", dd, sizeof(dd));
 						*wfname= stralloc( dd ) ;
 					}
 					else if (strcmp(s, "out") == 0)
 					{
-						sscanf(st+1, "%s", ss);
+						sscanf_s(st+1, "%s", ss, sizeof(ss));
 						if (strrchr(ss, FLDELIM) == NULL)
 						{
 							free ( *ofname) ;
@@ -97,7 +93,7 @@ void Gdata (FILE *fi, char *dsn, char *File, char **wfname, char **ofname,
 							*ofname = stralloc( File);
 							
 							if ((st = strrchr(*ofname, FLDELIM)) != NULL)
-								strcpy(st + 1, ss);
+								strcpy_s(st + 1, st-s-1, ss);
 						}
 						else
 						{
@@ -117,13 +113,13 @@ void Gdata (FILE *fi, char *dsn, char *File, char **wfname, char **ofname,
 		{
 			*Tini=15.0;
 			
-			while (fscanf(fi, "%s", s), s[0] != ';')
+			while (fscanf_s(fi, "%s", s, sizeof(s)), s[0] != ';')
 			{
 				if ((ce=strchr(s, ';')) != 0)
 					*ce = '\0';
 
 				if (s[0] == 'T')
-					sscanf(s, "%*[^=]=%lf", Tini);
+					sscanf_s(s, "%*[^=]=%lf", Tini);
 				else if ((st = strchr(s, '=')) != NULL)
 				{
 					*st = '\0';
@@ -144,15 +140,15 @@ void Gdata (FILE *fi, char *dsn, char *File, char **wfname, char **ofname,
 				}
 				else if (s[0] == '(')
 				{
-					sscanf(s, "(%d/%d)", &Mxs, &Dxs);
+					sscanf_s(s, "(%d/%d)", &Mxs, &Dxs);
 					*dayxs = FNNday(Mxs, Dxs);
 				}
 				// 周期定常計算への対応
 				else if (strcmp(s, "-periodic") == 0)
 				{
 					*perio = 'y';			// 周期定常計算フラグの変更
-					fscanf(fi, "%s", s);	// 計算する日付の読み込み
-					sscanf(s, "%d/%d", &Ms, &Ds);	// 計算する日付の取得
+					fscanf_s(fi, "%s", s, sizeof(s));	// 計算する日付の読み込み
+					sscanf_s(s, "%d/%d", &Ms, &Ds);	// 計算する日付の取得
 					*days = FNNday(Ms, Ds);
 					*dayxs = *days;
 					Daytm->Mon = Ms;
@@ -160,7 +156,7 @@ void Gdata (FILE *fi, char *dsn, char *File, char **wfname, char **ofname,
 				}
 				else if (strchr(s,'-') != 0)
 				{
-					sscanf(s, "%d/%d-%d/%d", &Ms,&Ds,&Me,&De);
+					sscanf_s(s, "%d/%d-%d/%d", &Ms,&Ds,&Me,&De);
 					*days = FNNday(Ms, Ds);
 					*daye = FNNday(Me, De);
 					if (Mxs == 0)
@@ -185,7 +181,7 @@ void Gdata (FILE *fi, char *dsn, char *File, char **wfname, char **ofname,
 		}
 		else if (strcmp(s, "PRINT") == 0)
 		{
-			while (fscanf(fi, "%s", s), s[0] != ';')
+			while (fscanf_s(fi, "%s", s, sizeof(s)), s[0] != ';')
 			{
 				if ((ce=strchr(s, ';')) != 0)
 					*ce = '\0';
@@ -204,12 +200,12 @@ void Gdata (FILE *fi, char *dsn, char *File, char **wfname, char **ofname,
 					DEBUG = 1 ;
 				else if (strchr(s, '-') == 0)
 				{
-					sscanf(s, "%d/%d", &Ms, &Ds);
+					sscanf_s(s, "%d/%d", &Ms, &Ds);
 					pday[ FNNday(Ms, Ds) ] = 1;
 				}
 				else
 				{
-					sscanf(s, "%d/%d-%d/%d", &Ms, &Ds, &Me, &De);
+					sscanf_s(s, "%d/%d-%d/%d", &Ms, &Ds, &Me, &De);
 					ns = FNNday(Ms, Ds);
 					ne = (ns < (n=FNNday(Me, De)) ? n : n+365);
 					for (n=ns; n <= ne; n++)
@@ -224,8 +220,9 @@ void Gdata (FILE *fi, char *dsn, char *File, char **wfname, char **ofname,
 			Eprint ( "<Gdata>", s );
    }
 
-   strcat ( strcpy ( s, *ofname ), ".log" ) ;
-   ferr = fopen ( s, "w" ) ;
+   strcpy_s ( s, sizeof(s), *ofname );
+   strcat_s ( s, sizeof(s),  ".log" ) ;
+   fopen_s (&ferr, s, "w" ) ;
 
    if ( logprn == 0 )
    {

--- a/Source/ee/eeinput_s.c
+++ b/Source/ee/eeinput_s.c
@@ -13,7 +13,7 @@
 //You should have received a copy of the GNU General Public License
 //along with Foobar.If not, see < https://www.gnu.org/licenses/>.
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include <stdlib.h>
 #include "common.h"
@@ -72,7 +72,7 @@ void Eeinput(char *Ipath, SIMCONTL *Simc, SCHDL *Schdl,
 	File = NULL;
 
 	s[0] = '\0';
-	sprintf(Err, ERRFMT, "(Eeinput)");
+	sprintf_s(Err, sizeof(Err), ERRFMT, "(Eeinput)");
 
 	//*Nexs=0 ;
 
@@ -87,7 +87,7 @@ void Eeinput(char *Ipath, SIMCONTL *Simc, SCHDL *Schdl,
 	Rmvls->Nrdpnl = Rmvls->Nmwall = 0;
 #endif
 
-	if ((fi = fopen("dayweek.efl", "r")) == 0)
+	if (fopen_s(&fi, "dayweek.efl", "r") != 0)
 	{
 		Eprint("<Eeinput>", "dayweek.efl");
 
@@ -103,7 +103,9 @@ void Eeinput(char *Ipath, SIMCONTL *Simc, SCHDL *Schdl,
 		dprdayweek(Simc->daywk);
 #endif
 
-	if ((fi = fopen(strcat(strcpy(s, Ipath), "schtba.ewk"), "r")) == 0)
+	strcpy_s(s, sizeof(s), Ipath);
+	strcat_s(s, sizeof(s), "schtba.ewk");
+	if (fopen_s(&fi, s, "r") != 0)
 	{
 		Eprint("<Eeinput>", "schtba.ewk");
 
@@ -124,7 +126,9 @@ void Eeinput(char *Ipath, SIMCONTL *Simc, SCHDL *Schdl,
 		Schdl->Nscw = Scw->end;
 	}
 
-	if ((fi = fopen(strcat(strcpy(s, Ipath), "schnma.ewk"), "r")) == 0)
+	strcpy_s(s, sizeof(s), Ipath);
+	strcat_s(s, sizeof(s), "schnma.ewk");
+	if (fopen_s(&fi, s, "r") != 0)
 	{
 		Eprint("<Eeinput>", "schnma.ewk");
 
@@ -153,7 +157,9 @@ void Eeinput(char *Ipath, SIMCONTL *Simc, SCHDL *Schdl,
 			Schdl->isw = NULL;
 	}
 
-	if ((fi = fopen(strcat(strcpy(s, Ipath), "bdata.ewk"), "r")) == 0)
+	strcpy_s(s, sizeof(s), Ipath);
+	strcat_s(s, sizeof(s), "bdata.ewk");
+	if (fopen_s(&fi, s, "r") != 0)
 	{
 		Eprint("<Eeinput>", "bdata.ewk");
 
@@ -162,16 +168,16 @@ void Eeinput(char *Ipath, SIMCONTL *Simc, SCHDL *Schdl,
 	}
 
 
-	while (fscanf(fi, "%s", s), printf("=== %s\n", s), s[0] != '*')
+	while (fscanf_s(fi, "%s", s, sizeof(s)), printf("=== %s\n", s), s[0] != '*')
 	{
 		if (strcmp("TITLE", s) == 0)
 		{
-			fscanf(fi, "%[^;];", Simc->title);
+			fscanf_s(fi, "%[^;];", Simc->title, sizeof(Simc->title));
 			printf("%s\n", Simc->title);
 		}
 		else if (strcmp("GDAT", s) == 0)
 		{
-			sprintf(hptest, "GDAT");
+			sprintf_s(hptest, sizeof(hptest), "GDAT");
 			HeapCheck(hptest);
 			Wd->RNtype = 'C';
 			Wd->Intgtsupw = 'N';
@@ -220,7 +226,7 @@ void Eeinput(char *Ipath, SIMCONTL *Simc, SCHDL *Schdl,
 
 		else if (strcmp("EXSRF", s) == 0)
 		{
-			sprintf(hptest, "EXSRF");
+			sprintf_s(hptest, sizeof(hptest), "EXSRF");
 			HeapCheck(hptest);
 			Exsfdata(fi, s, Exsf, Schdl, Simc);
 		}
@@ -232,7 +238,7 @@ void Eeinput(char *Ipath, SIMCONTL *Simc, SCHDL *Schdl,
 			PCMdata(fi, s, &Rmvls->PCM, &Rmvls->Npcm, &Rmvls->pcmiterate);
 		else if (strcmp("WALL", s) == 0)
 		{
-			sprintf(hptest, "Wallata");
+			sprintf_s(hptest, sizeof(hptest), "Wallata");
 			HeapCheck(hptest);
 
 			if (Fbmlist == NULL)
@@ -240,7 +246,7 @@ void Eeinput(char *Ipath, SIMCONTL *Simc, SCHDL *Schdl,
 			else
 				File = Fbmlist;
 
-			if ((fbmlist = fopen(File, "r")) == 0)
+			if (fopen_s(&fbmlist, File, "r") != 0)
 			{
 				Eprint("<Eeinput>", "wbmlist.efl");
 
@@ -263,7 +269,7 @@ void Eeinput(char *Ipath, SIMCONTL *Simc, SCHDL *Schdl,
 			Roomdata(fi, "Roomdata", Exsf->Exs, &dfwl, Rmvls, Schdl, Simc);
 			Balloc(Rmvls->Nsrf, Rmvls->Sd, Rmvls->Wall, &Rmvls->Mw, &Rmvls->Nmwall);
 			//////////////////////////////////////
-			sprintf(hptest, "Roomdata");
+			sprintf_s(hptest, sizeof(hptest), "Roomdata");
 			HeapCheck(hptest);
 			//if(Rmvls->Sd->alicsch != NULL)
 			//	printf("Balloc end NULL check\n") ;
@@ -439,12 +445,12 @@ void Eeinput(char *Ipath, SIMCONTL *Simc, SCHDL *Schdl,
 				}
 			}
 			shdp = *shadtb;
-			while (fscanf(fi, "%s", s), s[0] != '*'){
+			while (fscanf_s(fi, "%s", s, sizeof(s)), s[0] != '*'){
 				shdp->lpname = stralloc(s);
 				(*shadn)++;
 				shdp->indatn = 0;
-				while (fscanf(fi, "%s", s), s[0] != ';'){
-					sscanf(s, "%d/%d-%lf-%d/%d", &smonth, &sday, &shdp->shad[shdp->indatn], &emonth, &eday);
+				while (fscanf_s(fi, "%s", s, sizeof(s)), s[0] != ';'){
+					sscanf_s(s, "%d/%d-%lf-%d/%d", &smonth, &sday, &shdp->shad[shdp->indatn], &emonth, &eday);
 					shdp->ndays[shdp->indatn] = nennkann(smonth, sday);
 					shdp->ndaye[shdp->indatn] = nennkann(emonth, eday);
 					shdp->indatn = shdp->indatn + 1;
@@ -456,7 +462,8 @@ void Eeinput(char *Ipath, SIMCONTL *Simc, SCHDL *Schdl,
 
 		else
 		{
-			strcat(strcat(Err, "  "), s);
+			strcat_s(Err, sizeof(Err), "  ");
+			strcat_s(Err, sizeof(Err), s);
 			Eprint("<Eeinput>", Err);
 		}
 
@@ -489,7 +496,7 @@ void Eeinput(char *Ipath, SIMCONTL *Simc, SCHDL *Schdl,
 
 	//printf("Nop=%d Nlp=%d\n", Noplpmp->Nop, Noplpmp->Nlp);
 	//////////////////////////////////////
-	sprintf(hptest, "Innput End");
+	sprintf_s(hptest, sizeof(hptest), "Innput End");
 	HeapCheck(hptest);
 
 	if (SYSCMP_ID == 0)
@@ -534,7 +541,7 @@ void Eeinput(char *Ipath, SIMCONTL *Simc, SCHDL *Schdl,
 	Simc->daystartx = daystartx;
 	Simc->daystart = daystart;
 
-	strcpy(Simc->timeid, "MDT");
+	strcpy_s(Simc->timeid, sizeof(Simc->timeid), "MDT");
 
 	Simc->Ntimedyprt = Simc->dayend - Simc->daystart + 1;
 	Simc->Dayntime = 24 * 3600 / dtm;
@@ -733,7 +740,7 @@ void Eeinput(char *Ipath, SIMCONTL *Simc, SCHDL *Schdl,
 
 	//////////////////////////////////////
 	//printf("InputEnd\n");
-	sprintf(hptest, "Innput End");
+	sprintf_s(hptest, sizeof(hptest), "Innput End");
 	HeapCheck(hptest);
 
 	//Sd = Rmvls->Sd ;

--- a/Source/ee/eepathdat.c
+++ b/Source/ee/eepathdat.c
@@ -19,7 +19,7 @@
 
 //#define	 DEBUG  0
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -122,7 +122,7 @@ void Pathdata (FILE *f, char *errkey, SIMCONTL *Simc, WDAT *Wd, int  Ncompnt,  C
 
 	if ( ID == 0 )
 	{
-		while (fscanf(f, "%s", ss), *ss != '*')
+		while (fscanf_s(f, "%s", ss, sizeof(ss)), *ss != '*')
 		{
 			if ( DEBUG )
 			{
@@ -155,7 +155,7 @@ void Pathdata (FILE *f, char *errkey, SIMCONTL *Simc, WDAT *Wd, int  Ncompnt,  C
 			Mpath->plist = Plist;
 			Pelmpre = NULL ;
 
-			while (fscanf(f, "%s", s), *s != ';')
+			while (fscanf_s(f, "%s", s, sizeof(s)), *s != ';')
 			{
 				if ( DEBUG )
 				{
@@ -164,7 +164,7 @@ void Pathdata (FILE *f, char *errkey, SIMCONTL *Simc, WDAT *Wd, int  Ncompnt,  C
 
 				if (*s == '-')
 				{
-					fscanf(f, "%s", ss);
+					fscanf_s(f, "%s", ss, sizeof(ss));
 
 					if (strcmp(s + 1, "sys") == 0)
 						Mpath->sys = *ss;
@@ -175,11 +175,11 @@ void Pathdata (FILE *f, char *errkey, SIMCONTL *Simc, WDAT *Wd, int  Ncompnt,  C
 				}     
 				else if (*s == '>')
 				{
-					sprintf(sss, "Path%d", iPlist) ;
+					sprintf_s(sss, sizeof(sss), "Path%d", iPlist) ;
 					Plist->plistname = stralloc(sss) ;
 					Plist->pelm = Pelm;
 
-					while (fscanf(f, "%s", s), *s != '>')
+					while (fscanf_s(f, "%s", s, sizeof(s)), *s != '>')
 					{
 						if ( DEBUG )
 						{
@@ -188,7 +188,7 @@ void Pathdata (FILE *f, char *errkey, SIMCONTL *Simc, WDAT *Wd, int  Ncompnt,  C
 
 						if (*s == '(' )
 						{
-							i = sscanf(s + 1, "%lf", &Go);
+							i = sscanf_s(s + 1, "%lf", &Go);
 							if (i == 1)
 							{
 								Plist->Go = dcalloc(1, errkey);
@@ -200,7 +200,7 @@ void Pathdata (FILE *f, char *errkey, SIMCONTL *Simc, WDAT *Wd, int  Ncompnt,  C
 							}
 							else
 							{
-								sscanf(s + 1, "%[^)])", ss);
+								sscanf_s(s + 1, "%[^)])", ss, sizeof(ss));
 
 								if ( DEBUG )
 								{
@@ -223,7 +223,7 @@ void Pathdata (FILE *f, char *errkey, SIMCONTL *Simc, WDAT *Wd, int  Ncompnt,  C
 							// 流量比率設定フラグのセット
 							Mpath->rate = 'Y' ;
 
-							i = sscanf(s + 1, "%lf", &Go);
+							i = sscanf_s(s + 1, "%lf", &Go);
 							if (i == 1)
 							{
 								Plist->rate = dcalloc(1, errkey);
@@ -235,7 +235,7 @@ void Pathdata (FILE *f, char *errkey, SIMCONTL *Simc, WDAT *Wd, int  Ncompnt,  C
 							}
 							else
 							{
-								sscanf(s + 1, "%[^)])", ss);
+								sscanf_s(s + 1, "%[^)])", ss, sizeof(ss));
 
 								if ( DEBUG )
 								{
@@ -258,7 +258,7 @@ void Pathdata (FILE *f, char *errkey, SIMCONTL *Simc, WDAT *Wd, int  Ncompnt,  C
 							// 末端経路名称
 							if(strncmp(s,"name=",5) == 0)
 							{
-								sscanf(s, "%*[^=]=%s", ss) ;
+								sscanf_s(s, "%*[^=]=%s", ss, sizeof(ss)) ;
 								free(Plist->plistname) ;
 								Plist->plistname = NULL ;
 								Plist->plistname = stralloc(ss) ;
@@ -737,7 +737,7 @@ int		Mpathcount ( FILE *fi, int *Pl )
 	ad = ftell ( fi ) ;
 	*Pl = 0 ;
 
-	while ( fscanf ( fi, "%s", s ) != EOF && *s != '*' )
+	while ( fscanf_s ( fi, "%s", s, sizeof(s) ) != EOF && *s != '*' )
 	{
 		if ( strcmp ( s, ";" ) == 0 )
 			N++ ;
@@ -764,7 +764,7 @@ void	Plcount ( FILE *fi, int *N )
 	M = N ;
 	ad = ftell ( fi ) ;
 
-	while ( fscanf ( fi, "%s", s ) != EOF && *s != '*' )
+	while ( fscanf_s ( fi, "%s", s, sizeof(s) ) != EOF && *s != '*' )
 	{
 		if ( strcmp ( s, ";" ) == 0 )
 		{
@@ -776,7 +776,7 @@ void	Plcount ( FILE *fi, int *N )
 		if ( strcmp ( s, ">" ) == 0 )
 		{
 			i++ ;
-			fscanf ( fi, "%*[^>] %*c" ) ;
+			fscanf_s ( fi, "%*[^>] %*c" ) ;
 		}
 	}
 
@@ -800,20 +800,20 @@ int		Pelmcount ( FILE *fi )
 	i = 1 ;
 	N = 0 ;
 
-	while ( fscanf ( fi, "%s", s ) != EOF )
+	while ( fscanf_s ( fi, "%s", s, sizeof(s) ) != EOF )
 	{
 		i = 1 ;
 		if ( strcmp ( s, "*" ) == 0 )
 			break ;
 
-		while ( fscanf ( fi, "%s", s ) != EOF )
+		while ( fscanf_s ( fi, "%s", s, sizeof(s) ) != EOF )
 		{
 			if ( *s == ';' )
 				break ;
 
 			if ( strcmp ( s, "-f" ) == 0 )
 			{
-				fscanf ( fi, "%s", t ) ;
+				fscanf_s ( fi, "%s", t, sizeof(t) ) ;
 
 				if ( strcmp ( t, "W" ) == 0 || strcmp ( t, "a" ) == 0 )
 					i = 1 ;
@@ -821,7 +821,7 @@ int		Pelmcount ( FILE *fi )
 					i = 2 ;
 			}
 			if ( strcmp ( s, "-sys" ) == 0 )
-				fscanf ( fi, "%*s" ) ;
+				fscanf_s ( fi, "%*s" ) ;
 
 			if ( strcmp ( s, ">" ) != 0 && *s != '(' && *s != '-' && *s != ';' )
 			{

--- a/Source/ee/eepathlib_s.c
+++ b/Source/ee/eepathlib_s.c
@@ -17,7 +17,7 @@
 
 /* 経路の定義用関数 */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include "fesy.h"
 #include "fnesy.h"
@@ -160,7 +160,9 @@ void pelmco(char pflow, PELM *Pelm, char *errkey)
 		}
 	}
 
-	Errprint(err, strcat(strcpy(Err, errkey), " <pelmco>"), cmp->name); 
+	strcpy_s(Err, sizeof(Err), errkey);
+	strcat_s(Err, sizeof(Err), " <pelmco>");
+	Errprint(err, Err, cmp->name); 
 }
 /* ----------------------------------------------- */
 
@@ -386,7 +388,9 @@ void pelmci(char pflow, PELM *Pelm, char *errkey)
 		}
 	}
 
-	Errprint(err, strcat(strcpy(Err, errkey), " <pelmci>"),cmp->name);
+	strcpy_s(Err, sizeof(Err), errkey);
+	strcat_s(Err, sizeof(Err), " <pelmci>");
+	Errprint(err, Err, cmp->name);
 }
 /* ----------------------------------------------- */
 
@@ -406,8 +410,8 @@ void plistcpy(MPATH *Mpath, int *Npelm, PELM *Pelm, PLIST *Plist,
 
 	mpi->mpair = Mpath;
 
-	strcpy ( s, mpi->name ) ;
-	strcat ( s, ".x" ) ;
+	strcpy_s ( s, sizeof(s), mpi->name ) ;
+	strcat_s ( s, sizeof(s), ".x" ) ;
 	Mpath->name = stralloc ( s ) ;
 
 	/******************
@@ -452,8 +456,8 @@ void plistcpy(MPATH *Mpath, int *Npelm, PELM *Pelm, PLIST *Plist,
 
 		if (pli->name != NULL)
 		{
-			strcpy ( s, pli->name ) ;
-			strcat ( s, ".x" ) ;
+			strcpy_s ( s, sizeof(s), pli->name ) ;
+			strcat_s ( s, sizeof(s), ".x" ) ;
 			Plist->name = stralloc ( s ) ;
 
 			/***************************
@@ -480,7 +484,7 @@ void plistcpy(MPATH *Mpath, int *Npelm, PELM *Pelm, PLIST *Plist,
 				{
 					for (cmp = peli->cmp + 1; cmp < Compnt + Ncompnt; cmp++)
 					{
-						strcpy(s, cmp->name);
+						strcpy_s(s, sizeof(s), cmp->name);
 						if ((st = strchr(s, '.') )!= NULL)
 						{
 							*st = '\0';
@@ -750,7 +754,7 @@ void	pflowstrct ( int Nmpath, MPATH *Mpath )
 
 		/*if ( n != Mpath->NGv )
 		{
-		sprintf ( Err, "xxxx  Nundflow=%d  Ncbeq=%d  Name=%s\n",
+		sprintf_s ( Err, sizeof(Err), "xxxx  Nundflow=%d  Ncbeq=%d  Name=%s\n",
 		n, m, Mpath->name ) ;
 		Eprint ( "<pflowstrct>", Err ) ;
 		}*/

--- a/Source/ee/eepflow.c
+++ b/Source/ee/eepflow.c
@@ -16,7 +16,7 @@
 /*  pflow.c  */
 
 /* 流量の設定 */
-#define _CRT_SECURE_NO_WARNINGS
+
 
 #include <string.h>
 #include <stdio.h>
@@ -98,7 +98,7 @@ void Pflow(int Nmpath, MPATH *Mpath, WDAT *Wd)
 						{
 							if ( vc->x < 0.0 )
 							{
-								sprintf ( s, "%s のバルブ開度 %lf が不正です。",
+								sprintf_s ( s, sizeof(s), "%s のバルブ開度 %lf が不正です。",
 									vc->name, vc->x ) ;
 								Eprint ( "<Pflow>", s ) ;
 							}
@@ -236,7 +236,7 @@ void Pflow(int Nmpath, MPATH *Mpath, WDAT *Wd)
 					
 					if(Plist->pelm != NULL)
 					{
-						sprintf(Err, "Mpath=%s  lpath=%Ild  elm=%s  Go=%lf\n",
+						sprintf_s(Err, sizeof(Err), "Mpath=%s  lpath=%Ild  elm=%s  Go=%lf\n",
 							Mpath->name, Plist - mpi->plist, 
 							Plist->pelm->cmp->name, Go);
 					}
@@ -298,7 +298,7 @@ void Pflow(int Nmpath, MPATH *Mpath, WDAT *Wd)
 						
 						if (n < 0 || n >= NG)
 						{
-							sprintf ( Err, "n=%d", n ) ;
+							sprintf_s ( Err, sizeof(Err), "n=%d", n ) ;
 							Eprint ( "<Pflow>", Err ) ;
 							preexit ( ) ;
 							exit (EXIT_PFLOW) ;
@@ -336,7 +336,7 @@ void Pflow(int Nmpath, MPATH *Mpath, WDAT *Wd)
 						
 						if (n < 0 || n >= NG)
 						{
-							sprintf ( Err, "n=%d", n ) ;
+							sprintf_s ( Err, sizeof(Err), "n=%d", n ) ;
 							Eprint ( "<Pflow>", Err ) ;
 							preexit ( ) ;
 							exit (EXIT_PFLOW) ;

--- a/Source/ee/eesyseqv.c
+++ b/Source/ee/eesyseqv.c
@@ -141,7 +141,7 @@ void Syseqv(int Nelout, ELOUT *Elout, SYSEQ *Syseq)
 	
 	//	if ( Nsv > SYSEQMX )
 	//	{
-	//		sprintf ( Err, "syseq=%d  SYSEQMX=%d\n", Nsv, SYSEQMX ) ;
+	//		sprintf_s ( Err, sizeof(Err), "syseq=%d  SYSEQMX=%d\n", Nsv, SYSEQMX ) ;
 	//		Eprint ( "<Syseqv>", Err ) ;
 	//	}
 	

--- a/Source/ee/eevcdat.c
+++ b/Source/ee/eevcdat.c
@@ -15,7 +15,7 @@
 
 /* eevcdat.c */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <ctype.h>
 #include <stdlib.h>
 #include "common.h"
@@ -34,7 +34,7 @@ void Vcfdata(FILE *fi, SIMCONTL *Simcon)
 	int		i, N, j ;
 	char     s[SCHAR], Err[SCHAR], E[SCHAR*3+128];
 	
-	sprintf(Err, ERRFMT, "(vcfileint)");
+	sprintf_s(Err, sizeof(Err), ERRFMT, "(vcfileint)");
 	
 	//N = VCFILEMAX ;
 	N = VCFcount ( fi ) ;
@@ -59,7 +59,7 @@ void Vcfdata(FILE *fi, SIMCONTL *Simcon)
 			V->Estl.Npreq = V->Estl.Npprd = V->Estl.Ndata = 0 ;
 			V->Estl.Rq = NULL ;
 			V->Estl.Prq = NULL ;
-			strcpy ( V->Estl.vreq, "" ) ;
+			strcpy_s ( V->Estl.vreq, sizeof(V->Estl.vreq), "" ) ;
 
 			for ( j = 0; j < VTYPEMAX; j++ )
 				V->Estl.unit[j] = NULL ;
@@ -67,19 +67,19 @@ void Vcfdata(FILE *fi, SIMCONTL *Simcon)
 	}
 
 	Vcfile = Simcon->Vcfile;
-	while (fscanf(fi, "%s", s), *s != '*')
+	while (fscanf_s(fi, "%s", s, sizeof(s)), *s != '*')
 	{
 		Vcfile->name = stralloc(s);
-		while (fscanf(fi, "%s", s), *s != ';')
+		while (fscanf_s(fi, "%s", s, sizeof(s)), *s != ';')
 		{
 			if (strcmp(s, "-f") == 0)
 			{
-				fscanf(fi, "%s", s);
+				fscanf_s(fi, "%s", s, sizeof(s));
 				Vcfile->fname = stralloc(s);
 			}
 			else
 			{
-				sprintf ( E, "Vcfile=%s  %s %s", Vcfile->name, Err, s);
+				sprintf_s ( E, sizeof(E), "Vcfile=%s  %s %s", Vcfile->name, Err, s);
 				Eprint ( "<Vcfdata>", E ) ;
 			}
 		}
@@ -94,7 +94,7 @@ void Vcfdata(FILE *fi, SIMCONTL *Simcon)
 	
 	for (i = 0; i < Simcon->Nvcfile; i++, Vcfile++)
 	{
-		if((Vcfile->fi = fopen(Vcfile->fname, "r")) == 0)
+		if(fopen_s(&(Vcfile->fi), Vcfile->fname, "r") != 0)
 		{
 			Eprint ( "<Vcfdata>", Vcfile->fname ) ;
 
@@ -151,7 +151,7 @@ int	VCFcount ( FILE *fi )
 
 	ad = ftell ( fi ) ;
 
-	while ( fscanf ( fi, " %s ", s ), s[0] != '*' )
+	while ( fscanf_s ( fi, " %s ", s, sizeof(s) ), s[0] != '*' )
 	{
 		if ( strcmp ( s, "-f" ) == 0 )
 			N++ ;
@@ -171,10 +171,10 @@ void flindat(FLIN *Flin)
 	int  n = 0;
 	char     Err[SCHAR];
 	
-	sprintf(Err, ERRFMT, "(flindat)");
+	sprintf_s(Err, sizeof(Err), ERRFMT, "(flindat)");
 	
 	ss = Flin->cmp->tparm;
-	while(sscanf(ss, "%s", s), strchr(s,'*') == NULL)
+	while(sscanf_s(ss, "%s", s, sizeof(s)), strchr(s,'*') == NULL)
 	{
 		ss += strlen(s);
 		while(isspace(*ss))
@@ -351,14 +351,14 @@ void Vcfinput(DAYTM *Daytm, int Nvcfile, VCFILE *Vcfile, char perio)
 		}
 		if ( idend == 0 )
 		{
-			sprintf(E, "Vcfinput file-end: %s\n", Vcfile->fname);
+			sprintf_s(E, sizeof(E), "Vcfinput file-end: %s\n", Vcfile->fname);
 
 			Eprint ( "<Vcfinput>", E );
 		}
 		
 		if ( iderr )
 		{
-			sprintf(E,"Vcfinput xxx file=%s prog_MM/DD/TM=%d/%d/%d file_MM/DD/TM=%d/%d/%d\n",
+			sprintf_s(E, sizeof(E), "Vcfinput xxx file=%s prog_MM/DD/TM=%d/%d/%d file_MM/DD/TM=%d/%d/%d\n",
 				Vcfile->fname, Daytm->Mon, Daytm->Day, Daytm->ttmm,
 				Tmdt.Mon, Tmdt.Day, Tmdt.Time);
 			

--- a/Source/ee/epsinput.c
+++ b/Source/ee/epsinput.c
@@ -15,7 +15,7 @@
 
 /* epsinput.c */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -35,26 +35,26 @@ void esondat(FILE *fi, ESTL *Estl)
 	
 	Estl->catnm = NULL;
 	
-	while (fscanf(fi, "%s", s), *s != '#')
+	while (fscanf_s(fi, "%s", s, sizeof(s)), *s != '#')
 	{
 		if (strcmp(s, "-t") == 0)
 		{
-			fscanf(fi, " %[^;];", s);
+			fscanf_s(fi, " %[^;];", s, sizeof(s));
 			Estl->title = stralloc(s);
 		}
 		else if (strcmp(s, "-w") == 0)
 		{
-			fscanf(fi, "%s", s);
+			fscanf_s(fi, "%s", s, sizeof(s));
 			Estl->wdatfile = stralloc(s);
 		}	 
 		else if (strcmp(s, "-tid") == 0)
 		{
-			fscanf(fi, " %c", &Estl->tid);
+			fscanf_s(fi, " %c", &Estl->tid, 1);
 		}
 		else if (strcmp(s, "-u") == 0)
 		{
 			i = 0;
-			while (fscanf(fi, "%s", s), *s != ';')
+			while (fscanf_s(fi, "%s", s, sizeof(s)), *s != ';')
 			{
 				Estl->unit[i] = stralloc(s);
 				i++ ;
@@ -62,14 +62,14 @@ void esondat(FILE *fi, ESTL *Estl)
 			}
 		}
 		else if (strcmp(s, "-Ntime") == 0)
-			fscanf(fi, " %d",  &Estl->Ntime);
+			fscanf_s(fi, " %d",  &Estl->Ntime);
 		
 		else if (strcmp(s, "-dtm") == 0)
-			fscanf(fi, " %d",  &Estl->dtm);
+			fscanf_s(fi, " %d",  &Estl->dtm);
 		
 		else if (strcmp(s, "-tmid") == 0)
 		{
-			fscanf(fi, "%s", s);
+			fscanf_s(fi, "%s", s, sizeof(s));
 			Estl->timeid = stralloc(s);
 			Estl->ntimeid = (int)strlen(Estl->timeid);
 		}
@@ -92,16 +92,16 @@ void esondat(FILE *fi, ESTL *Estl)
 
 			Estl->Ndata = 0;
 			catnm = Estl->catnm;
-			while(fscanf(fi, "%s", s), *s != '*')
+			while(fscanf_s(fi, "%s", s, sizeof(s)), *s != '*')
 			{
 				catnm->name = stralloc(s);
 				catnm->Ncdata = 0;
-				fscanf(fi, "%d", &catnm->N);
+				fscanf_s(fi, "%d", &catnm->N);
 				for (i = 0; i < catnm->N; i++)
 				{
-					fscanf(fi, "%s %d %d", s, &Nparm, &Ndat);
+					fscanf_s(fi, "%s %d %d", s, sizeof(s), &Nparm, &Ndat);
 					for (j = 0; j < Nparm - 1; j++)
-						fscanf(fi, "%s", s);
+						fscanf_s(fi, "%s", s, sizeof(s));
 					Estl->Ndata += Ndat;
 					catnm->Ncdata += Ndat;
 				}
@@ -110,13 +110,13 @@ void esondat(FILE *fi, ESTL *Estl)
 		}
 		else if (strcmp(s, "-wdloc") == 0)
 		{
-			fscanf(fi, "%[^;];", s);
+			fscanf_s(fi, "%[^;];", s, sizeof(s));
 			
-			strcat(s, " ;");
+			strcat_s(s, sizeof(s), " ;");
 			Estl->wdloc = stralloc(s);
 		}
 		else if (strcmp(s, "-Ndata") == 0)
-			fscanf(fi, " %d",  &Estl->Ndata);
+			fscanf_s(fi, " %d",  &Estl->Ndata);
 		
 		
 		else if (s[strlen(s) - 1] == '#')
@@ -264,7 +264,7 @@ void esoint(FILE *fi, char *err, int Ntime,
 	
 	for (i = 0; i < Estl->Ndata; i++, Tlist++)
 	{
-		fscanf(fi, " %[^_]_%s %c %c", nm, id, &Tlist->vtype, &Tlist->ptype);
+		fscanf_s(fi, " %[^_]_%s %c %c", nm, sizeof(nm), id, sizeof(id), &Tlist->vtype, 1, &Tlist->ptype, 1);
 		
 		switch (Tlist->vtype)
 		{
@@ -288,7 +288,7 @@ void esoint(FILE *fi, char *err, int Ntime,
 				Tlist->stype = 'm';
 				break;
 			default:
-				sprintf ( E, "xxxx %s xxx  %s %s %c %c %c\n",
+				sprintf_s ( E, sizeof(E), "xxxx %s xxx  %s %s %c %c %c\n",
 					err, nm, id, id[strlen(id)-1], Tlist->vtype, Tlist->ptype);
 				Eprint ( "<esoint>", E ) ;
 			}
@@ -421,7 +421,7 @@ int tmdata(VCFILE *Vcfile, TMDT *Tmdt, DAYTM *Daytm, char perio)
 	Estl = &Vcfile->Estl ;
 	r = 1 ;
 	
-	while ( fscanf ( fi, "%s", s ) != EOF )
+	while ( fscanf_s ( fi, "%s", s, sizeof(s) ) != EOF )
 	{
 		//printf ( "s=%s  ", s ) ;
 
@@ -442,14 +442,14 @@ int tmdata(VCFILE *Vcfile, TMDT *Tmdt, DAYTM *Daytm, char perio)
 			for ( i = 0; i < Estl->ntimeid; i++ )
 			{
 				if ( i > 0 )
-					fscanf ( fi, "%s", s ) ;
+					fscanf_s ( fi, "%s", s, sizeof(s) ) ;
 				
 				/*****printf("<<tmdata>> i=%d s=%s\n", i, s);/*****/
 				
 				switch (Estl->timeid[i])
 				{
 				case 'Y':
-					strcpy(Tmdt->year, s);
+					strcpy_s(Tmdt->year, sizeof(Tmdt->year), s);
 					Tmdt->Year = atoi(s);
 					Tmdt->dat[i] = Tmdt->year;
 
@@ -458,7 +458,7 @@ int tmdata(VCFILE *Vcfile, TMDT *Tmdt, DAYTM *Daytm, char perio)
 
 					break;
 				case 'M':
-					strcpy(Tmdt->mon, s);
+					strcpy_s(Tmdt->mon, sizeof(Tmdt->mon), s);
 					Tmdt->Mon = atoi(s);
 					Tmdt->dat[i] = Tmdt->mon;
 
@@ -467,7 +467,7 @@ int tmdata(VCFILE *Vcfile, TMDT *Tmdt, DAYTM *Daytm, char perio)
 
 					break;
 				case 'D':
-					strcpy(Tmdt->day, s);
+					strcpy_s(Tmdt->day, sizeof(Tmdt->day), s);
 					Tmdt->Day = atoi(s);
 					Tmdt->dat[i] = Tmdt->day;
 
@@ -476,11 +476,11 @@ int tmdata(VCFILE *Vcfile, TMDT *Tmdt, DAYTM *Daytm, char perio)
 
 					break;
 				case 'W':
-					strcpy(Tmdt->wkday, s);
+					strcpy_s(Tmdt->wkday, sizeof(Tmdt->wkday), s);
 					Tmdt->dat[i] = Tmdt->wkday;
 					break;
 				case 'T':
-					strcpy(Tmdt->time, s);
+					strcpy_s(Tmdt->time, sizeof(Tmdt->time), s);
 					if ((st = strchr(s, ':')) != NULL)
 						*st = '.';
 					Tmdt->Time = (int)(atof(s) * 100.0 + 0.5);
@@ -497,7 +497,7 @@ int tmdata(VCFILE *Vcfile, TMDT *Tmdt, DAYTM *Daytm, char perio)
 			else
 			{
 				for ( i = 0; i < Estl->Ndata; i++ )
-					fscanf ( fi, "%*s" ) ;
+					fscanf_s ( fi, "%*s" ) ;
 			}
 		}
 	}
@@ -516,7 +516,7 @@ void esdatgt(FILE *fi, int i, int Ndata, TLIST *Tlist)
 	
 	for (j = 0; j < Ndata; j++, Tlist++)
 	{
-		fscanf(fi, "%s", s);
+		fscanf_s(fi, "%s", s, sizeof(s));
 		if (Tlist->req == 'y' || Tlist->vtype == 'h' || Tlist->vtype == 'H')
 		{
 			switch (Tlist->ptype)

--- a/Source/ee/evcwdfl.c
+++ b/Source/ee/evcwdfl.c
@@ -15,7 +15,7 @@
 
 /* evcwdfl.c  */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdlib.h>
 #include <ctype.h>
 #include <math.h>
@@ -39,14 +39,14 @@ void wdflinit(SIMCONTL *Simc, ESTL *Estl, TLIST *Tlist)
 	
 	/****printf("<<wdflinit>> wdloc=%s\n", s);****/
 	
-	sprintf(Err, ERRFMT, "(wdflinit)");   
+	sprintf_s(Err, sizeof(Err), ERRFMT, "(wdflinit)");   
 
 	Locinit (Simc->Loc) ;
 	loc = Simc->Loc;
 
 	m = -1;
 	
-	while (sscanf(s, "%s", ss), *s != ';')
+	while (sscanf_s(s, "%s", ss, sizeof(ss)), *s != ';')
 	{
 		N = (int)strlen(ss);
 		if ((st = strchr(ss, '=')) != NULL)

--- a/Source/esy/eschdata.c
+++ b/Source/esy/eschdata.c
@@ -15,7 +15,7 @@
 
 /*   schdata.c  */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <malloc.h>
@@ -35,7 +35,9 @@ void Dayweek(FILE *fi, char *Ipath, int *daywk, int key)
 	int   ds, de, dd, d, id=0, M, D;
 	FILE	 *fw ;
 	
-	if (( fw = fopen (strcat(strcpy(s, Ipath), "week.ewk"), "r" )) == 0 )
+	strcpy_s(s, sizeof(s), Ipath);
+	strcat_s(s, sizeof(s), "week.ewk");
+	if (fopen_s (&fw, s, "r" ) != 0 )
 	{
 		Eprint ( "<Dayweek>", "week.ewk" ) ;
 
@@ -44,12 +46,12 @@ void Dayweek(FILE *fi, char *Ipath, int *daywk, int key)
 	}
 	
 	if ( key == 0 )
-		fscanf(fi, "%d/%d=%s", &M, &D, s);
+		fscanf_s(fi, "%d/%d=%s", &M, &D, s, sizeof(s));
 	else
 	{
-		fscanf ( fi, "%*s" ) ;
+		fscanf_s ( fi, "%*s" ) ;
 		
-		fscanf ( fw, "%d/%d=%s", &M, &D, s);
+		fscanf_s ( fw, "%d/%d=%s", &M, &D, s, sizeof(s));
 	}
 	
 	for ( d = 0; d < 8; d++ )
@@ -72,13 +74,13 @@ void Dayweek(FILE *fi, char *Ipath, int *daywk, int key)
 		if (id > 6 )
 			id = 0;
 	}
-	while (fscanf(fi, "%s", s), s[0] != ';')
+	while (fscanf_s(fi, "%s", s, sizeof(s)), s[0] != ';')
 	{
 		if ((ce=strchr(s, ';')) != 0)
 			*ce = '\0';
 		if (strchr(s,'/') != 0)
 		{
-			sscanf(s, "%d/%d", &M, &D);
+			sscanf_s(s, "%d/%d", &M, &D);
 			d = FNNday(M, D);
 			daywk[d] = 7;
 		}
@@ -112,7 +114,7 @@ void Schtable (FILE *fi, char *dsn, SCHDL *Schdl )
 	Dsch = Dh = NULL ;
 	Dscw = Dw = NULL ;
 
-	sprintf (E, ERRFMT, dsn);
+	sprintf_s (E, sizeof(E), ERRFMT, dsn);
 
 	if ( ic == 0 )
 	{
@@ -212,11 +214,11 @@ void Schtable (FILE *fi, char *dsn, SCHDL *Schdl )
 	Dsch = Schdl->Dsch ;
 	Dscw = Schdl->Dscw ;
 	
-	while (fscanf(fi,"%s", s), s[0] != '*')
+	while (fscanf_s(fi,"%s", s, sizeof(s)), s[0] != '*')
 	{  
 		if (strcmp(s, "-ssn") == 0 || strcmp(s, "SSN") == 0)
 		{
-			while (fscanf(fi,"%s", s), s[0] != ';')
+			while (fscanf_s(fi,"%s", s, sizeof(s)), s[0] != ';')
 			{
 				if ((ce=strchr(s,';')) != 0)
 					*ce='\0';
@@ -230,7 +232,7 @@ void Schtable (FILE *fi, char *dsn, SCHDL *Schdl )
 				}
 				else
 				{ 
-					sscanf(s, "%d/%d-%d/%d", &Ms, &Ds, &Me, &De); 
+					sscanf_s(s, "%d/%d-%d/%d", &Ms, &Ds, &Me, &De); 
 					js++ ;
 					Sn->sday[js] = FNNday(Ms, Ds);
 					Sn->eday[js] = FNNday(Me, De);
@@ -242,7 +244,7 @@ void Schtable (FILE *fi, char *dsn, SCHDL *Schdl )
 		else if (strcmp(s, "-wkd") == 0 || strcmp(s, "WKD") == 0)
 		{
 			j=9;
-			while (fscanf(fi,"%s", s), s[0] != ';')
+			while (fscanf_s(fi,"%s", s, sizeof(s)), s[0] != ';')
 			{ 
 				if ((ce=strchr(s,';')) != 0)
 					*ce='\0';
@@ -269,7 +271,7 @@ void Schtable (FILE *fi, char *dsn, SCHDL *Schdl )
 		}
 		else if (strcmp(s, "-v") == 0 || strcmp(s, "VL") == 0)
 		{
-			while (fscanf(fi,"%s", s), s[0] != ';')
+			while (fscanf_s(fi,"%s", s, sizeof(s)), s[0] != ';')
 			{
 				if ((ce=strchr(s,';')) != 0)
 					*ce='\0';
@@ -293,7 +295,7 @@ void Schtable (FILE *fi, char *dsn, SCHDL *Schdl )
 //						printf ("<Schtable> Name=%s  MAX=%d  jsc=%d\n",
 //						Dh->name, SCDAYTMMAX, jsc) ;
 
-					sscanf(s,"%d-(%lf)-%d", &Dh->stime[jsc], &Dh->val[jsc], &Dh->etime[jsc] ) ;
+					sscanf_s(s,"%d-(%lf)-%d", &Dh->stime[jsc], &Dh->val[jsc], &Dh->etime[jsc] ) ;
 				}
 				if (ce) break;
 			} 
@@ -302,20 +304,20 @@ void Schtable (FILE *fi, char *dsn, SCHDL *Schdl )
 		else if (strcmp(s, "-s") == 0 || strcmp(s, "SW") == 0)
 		{ 
 			Nmod = 0;
-			fscanf(fi, " %s ", s);
+			fscanf_s(fi, " %s ", s, sizeof(s));
 
 			sw++ ;
 			Dw = Dscw + sw ;
 			Dw->name = stralloc ( s);
 			jsw= -1; 
 			
-			while (fscanf(fi,"%s", s), s[0] != ';')
+			while (fscanf_s(fi,"%s", s, sizeof(s)), s[0] != ';')
 			{ 
 				if ((ce=strchr(s,';')) != 0)
 					*ce='\0';
 				
 				jsw++;
-				sscanf(s,"%d-(%c)-%d", &Dw->stime[jsw], &code, &Dw->etime[jsw]);
+				sscanf_s(s,"%d-(%c)-%d", &Dw->stime[jsw], &code, 1, &Dw->etime[jsw]);
 				Dw->mode[jsw] = code ;
 				
 				for ( j = 0; j < Nmod; j++)
@@ -377,18 +379,18 @@ void Schdata (FILE *fi, char *dsn, int *daywk, SCHDL *Schdl )
 
 //	SchCount ( fi, &i, &i, &vl, &sws ) ;
 
-	sprintf (E, ERRFMT, dsn);
+	sprintf_s (E, sizeof(E), ERRFMT, dsn);
 	i = Sch->end - 1;
 	j = Scw->end - 1;
 	
-	while (fscanf(fi,"%s", s), s[0] != '*')
+	while (fscanf_s(fi,"%s", s, sizeof(s)), s[0] != '*')
 	{   
 		if (strcmp(s, "-v") == 0 || strcmp(s, "VL") == 0)
 			dmod = 'v';
 		else
 			dmod = 'w';
 		
-		fscanf(fi,"%s", s);
+		fscanf_s(fi,"%s", s, sizeof(s));
 		
 		if (dmod == 'v')
 		{
@@ -411,22 +413,22 @@ void Schdata (FILE *fi, char *dsn, int *daywk, SCHDL *Schdl )
 				*day1 = - 1 ;
 		}
 		
-		while (fscanf(fi,"%s", s),  *s != ';')
+		while (fscanf_s(fi,"%s", s, sizeof(s)),  *s != ';')
 		{
 			if (( ce = strchr ( s, ';' )) != 0 )
 				*ce = '\0' ;  
 			*sname = *wname = '\0' ;
 			is = iw = sc = sw = -1 ;
 			
-			sscanf ( s, "%[^:]:%s", dname, ss);
+			sscanf_s ( s, "%[^:]:%s", dname, sizeof(dname), ss, sizeof(ss));
 			if ( strchr ( ss, '-') == 0 )
-				sscanf ( ss, "%s", sname ) ;
+				sscanf_s ( ss, "%s", sname, sizeof(sname) ) ;
 			else
 			{
 				if ( *ss == '-' )
-					sscanf ( &ss[1], "%s", wname);
+					sscanf_s ( &ss[1], "%s", wname, sizeof(wname));
 				else
-					sscanf(ss, "%[^-]-%s", sname, wname);
+					sscanf_s(ss, "%[^-]-%s", sname, sizeof(sname), wname, sizeof(wname));
 			}
 			
 			/************************ 
@@ -441,16 +443,28 @@ void Schdata (FILE *fi, char *dsn, int *daywk, SCHDL *Schdl )
 			printf("-- dname:s,w,= %s  %s  %s\n",dname,sname,wname);
 			********************/
 			
-			if (sname[0] != '\0')
-				is= idssn(sname, Seasn, strcat(strcpy(err,E),sname));
-			if (wname[0] != '\0')
-				iw= idwkd(wname, Wkdy, strcat(strcpy(err,E),wname));
+			if (sname[0] != '\0') {
+				strcpy_s(err, sizeof(err), E);
+				strcat_s(err, sizeof(err), sname);
+				is= idssn(sname, Seasn, err);
+			}
+			if (wname[0] != '\0') {
+				strcpy_s(err, sizeof(err), E);
+				strcat_s(err, sizeof(err), wname);
+				iw= idwkd(wname, Wkdy, err);
+			}
 			if (dname[0] != '\0')
 			{
-				if (dmod == 'v')
-					sc= iddsc(dname, Dsch, strcat(strcpy(err,E),dname));
-				else 
-					sw= iddsw(dname, Dscw, strcat(strcpy(err,E),dname));
+				if (dmod == 'v') {
+					strcpy_s(err, sizeof(err), E);
+					strcat_s(err, sizeof(err), dname);
+					sc= iddsc(dname, Dsch, err);
+				}
+				else {
+					strcpy_s(err, sizeof(err), E);
+					strcat_s(err, sizeof(err), dname);
+					sw= iddsw(dname, Dscw, err);
+				}
 			}
 			if ( is >= 0 )
 				N = (Seasn+is)->N ;
@@ -516,7 +530,9 @@ void Schname (char *Ipath, char *dsn, SCHDL *Schdl )
 	FILE	*fi ;
 	int		ssnmx, vlmx, swmx ;
 
-	if (( fi = fopen (strcat(strcpy(s, Ipath), "schnma.ewk"), "r" )) == 0 )
+	strcpy_s(s, sizeof(s), Ipath);
+	strcat_s(s, sizeof(s), "schnma.ewk");
+	if (fopen_s (&fi, s, "r" ) != 0 )
 	{
 		Eprint ( "<Schname>", "schnma.ewk" ) ;
 
@@ -581,7 +597,7 @@ void Schname (char *Ipath, char *dsn, SCHDL *Schdl )
 	N = Dsch->end ;
 	Sch = Schdl->Sch + i ;
 
-	sprintf (E, ERRFMT, dsn);
+	sprintf_s (E, sizeof(E), ERRFMT, dsn);
 
 	for ( sc = sco; sc < N; sc++, Sch++ )
 	{
@@ -639,7 +655,7 @@ void	SchCount ( FILE *fi, int *ssn, int *wkd, int *vl, int *sw,
 
 	*ssn = *wkd = *vl = *sw = 0 ;
 
-	while ( fscanf ( fi, "%s", s ), *s != '*' )
+	while ( fscanf_s ( fi, "%s", s, sizeof(s) ), *s != '*' )
 	{
 		if ( strcmp ( s, "-ssn" ) == 0 || strcmp ( s, "SSN" ) == 0 )
 		{
@@ -674,7 +690,7 @@ int		Schcmpcount ( FILE *fi )
 	char	s[SCHAR] ;
 	
 	N = 0 ;
-	while ( fscanf ( fi, "%s", s ) != EOF )
+	while ( fscanf_s ( fi, "%s", s, sizeof(s) ) != EOF )
 	{
 		if ( *s == ';' )
 			break ;

--- a/Source/esy/escntldat.c
+++ b/Source/esy/escntldat.c
@@ -15,7 +15,7 @@
 
 /* esccntldat.c */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include <string.h>
 #include <malloc.h>
@@ -49,7 +49,7 @@ void Contrldata(FILE *fi, CONTL **Ct, int *Ncontl, CTLIF **Ci, int *Nctlif,
 	Hload = HEATING_LOAD;
 	Cload = COOLING_LOAD;
 	HCload = HEATCOOL_LOAD;
-	sprintf(Err, ERRFMT, "(Contrldata)");
+	sprintf_s(Err, sizeof(Err), ERRFMT, "(Contrldata)");
 
 	ContrlCount ( fi, &Ni, &N ) ;
 
@@ -111,7 +111,7 @@ void Contrldata(FILE *fi, CONTL **Ct, int *Ncontl, CTLIF **Ci, int *Nctlif,
 	ctlst = Ctlst;
 	load = NULL;
 
-	while (fscanf(fi, "%s", s), *s != '*')
+	while (fscanf_s(fi, "%s", s, sizeof(s)), *s != '*')
 	{
 		if (load != NULL)
 			free(load);
@@ -131,7 +131,7 @@ void Contrldata(FILE *fi, CONTL **Ct, int *Ncontl, CTLIF **Ci, int *Nctlif,
 
 				Contl->type = 'c';
 				Contl->cif = Ctlif;
-				fscanf(fi, " (%[^)])", s);
+				fscanf_s(fi, " (%[^)])", s, sizeof(s));
 
 				ctifdecode(s, Ctlif, Simc, Ncompnt, Compnt, Nmpath, Mpath, Wd, Exsf, Schdl);
 				Ctlif++;
@@ -154,7 +154,7 @@ void Contrldata(FILE *fi, CONTL **Ct, int *Ncontl, CTLIF **Ci, int *Nctlif,
 				else
 					Contl->andandcif = Ctlif ;
 
-				fscanf(fi, " (%[^)])", s);
+				fscanf_s(fi, " (%[^)])", s, sizeof(s));
 
 				ctifdecode(s, Ctlif, Simc, Ncompnt, Compnt, Nmpath, Mpath, Wd, Exsf, Schdl);
 				Ctlif++;
@@ -173,7 +173,7 @@ void Contrldata(FILE *fi, CONTL **Ct, int *Ncontl, CTLIF **Ci, int *Nctlif,
 
 				Contl->type = 'c';
 				Contl->orcif = Ctlif;
-				fscanf(fi, " (%[^)])", s);
+				fscanf_s(fi, " (%[^)])", s, sizeof(s));
 
 				ctifdecode(s, Ctlif, Simc, Ncompnt, Compnt, Nmpath, Mpath, Wd, Exsf, Schdl);
 				Ctlif++;
@@ -215,7 +215,7 @@ void Contrldata(FILE *fi, CONTL **Ct, int *Ncontl, CTLIF **Ci, int *Nctlif,
 			else if (strcmp(s, "-e") == 0)
 			{
 
-				fscanf(fi, "%s", s);
+				fscanf_s(fi, "%s", s, sizeof(s));
 				cmp = Compnt;
 				for (i = 0; i < Ncompnt; i++, cmp++)
 				{
@@ -261,7 +261,7 @@ void Contrldata(FILE *fi, CONTL **Ct, int *Ncontl, CTLIF **Ci, int *Nctlif,
 					err = ctlrgtptr(st, &Ctlst->rgt, Simc, Ncompnt, Compnt, Nmpath, Mpath,
 						Wd, Exsf, Schdl, Ctlst->type);
 				}
-				sprintf(Er, " %s = %s", s, st);
+				sprintf_s(Er, sizeof(Er), " %s = %s", s, st);
 				Errprint(err, "<Contrldata>", Er);
 			}
 			else if ( strcmp ( s, "TVALV" ) == 0 )
@@ -282,7 +282,7 @@ void Contrldata(FILE *fi, CONTL **Ct, int *Ncontl, CTLIF **Ci, int *Nctlif,
 				Eprint("<Contrldata>", s);
 			}
 		}
-		while (fscanf(fi, "%s", s), *s != ';' ); 
+		while (fscanf_s(fi, "%s", s, sizeof(s)), *s != ';' ); 
 
 		Ctlst++;
 		*Nctlst = (int)(Ctlst - ctlst) ;
@@ -318,7 +318,7 @@ void	ContrlCount ( FILE *fi, int *Nif, int *N )
 
 	ad = ftell ( fi ) ;
 
-	while ( fscanf ( fi, " %s ", s ), s[0] != '*' )
+	while ( fscanf_s ( fi, " %s ", s, sizeof(s) ), s[0] != '*' )
 	{
 		if ( strcmp ( s, "if" ) == 0 || strcmp ( s, "AND" ) == 0
 			|| strcmp ( s, "OR" ) == 0 )
@@ -348,7 +348,7 @@ void ctifdecode(char *s, CTLIF *ctlif,
 	int  err;
 	VPTR vptr, vpath;
 
-	sscanf(s, "%s %s %s", lft, op, rgt);
+	sscanf_s(s, "%s %s %s", lft, sizeof(lft), op, sizeof(op), rgt, sizeof(rgt));
 	/**************
 	printf("   ctifdecode  %s |  %s  | %s\n", lft, op, rgt);
 	**************/

--- a/Source/esy/escntllb_s.c
+++ b/Source/esy/escntllb_s.c
@@ -15,7 +15,7 @@
 
 /* escntllb_s.c */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdlib.h>
 #include "MODEL.h"   /*-----higuchi 070918---*/
 #include "fesy.h"
@@ -73,7 +73,7 @@ int strkey(char *s, char **key)
 		return 0;
 	else
 	{  
-		strcpy(ss, s); 
+		strcpy_s(ss, sizeof(ss), s); 
 		
 		key[0] = ss;
 		nk = 1;

--- a/Source/esy/esidcode_s.c
+++ b/Source/esy/esidcode_s.c
@@ -15,7 +15,7 @@
 
 /*     esidcode_s.c       */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include "fesy.h"
 #include "fnesy.h"
 #include "fnlib.h"
@@ -129,7 +129,7 @@ int idroom (char *code, ROOM *Room, char *err)
 
 		if ( j == N )
 		{
-			sprintf ( E, "Room=%s  %s", code, err ) ;
+			sprintf_s ( E, sizeof(E), "Room=%s  %s", code, err ) ;
 			Eprint ( "<idroom>", E ) ;
 		}
 	}

--- a/Source/func/COORDNT.c
+++ b/Source/func/COORDNT.c
@@ -19,7 +19,7 @@
 						FILE=COORDNT.c
 						Create Date=1999.6.7
 						*/
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include <math.h>
 #include <string.h>
@@ -67,7 +67,7 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 					chWA = cos((BDP[i].SBLK[j].WA - BDP[i].Wb)*M_rad);
 					shWA = sin((BDP[i].SBLK[j].WA - BDP[i].Wb)*M_rad);
 
-					lp[k].opname = stralloc(BDP[i].SBLK[j].snbname);
+					strcpy_s(lp[k].opname, OPNAME_SZ, BDP[i].SBLK[j].snbname);
 					lp[k].wa = BDP[i].Wa;
 					lp[k].wb = BDP[i].Wb + (180.0 - BDP[i].SBLK[j].WA);
 					if (lp[k].wb > 180.0)
@@ -126,7 +126,7 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 					chWA = cos((90.0 - BDP[i].Wb)*M_rad);
 					shWA = sin((90.0 - BDP[i].Wb)*M_rad);
 
-					lp[k].opname = stralloc(BDP[i].SBLK[j].snbname);
+					strcpy_s(lp[k].opname, OPNAME_SZ, BDP[i].SBLK[j].snbname);
 
 					lp[k].wa = BDP[i].Wa;
 					lp[k].wb = BDP[i].Wb + 90.0;
@@ -171,9 +171,9 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 
 					//HOUSEN2(&lp[k].P[0],&lp[k].P[1],&lp[k].P[2],&lp[k].e) ;
 
-					strcpy(name, "2");
-					strcat(name, lp[k].opname);
-					lp[k + 1].opname = stralloc(name);
+					strcpy_s(name, sizeof(name), "2");
+					strcat_s(name, sizeof(name), lp[k].opname);
+					strcpy_s(lp[k + 1].opname, OPNAME_SZ, name);
 
 					lp[k + 1].wa = BDP[i].Wa - 90.0;
 					if (lp[k + 1].wa <= -180.0)
@@ -210,9 +210,9 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 
 					//HOUSEN2(&lp[k+1].P[0],&lp[k+1].P[1],&lp[k+1].P[2],&lp[k+1].e) ;
 
-					strcpy(name, "3");
-					strcat(name, lp[k].opname);
-					lp[k + 2].opname = stralloc(name);
+					strcpy_s(name, sizeof(name), "3");
+					strcat_s(name, sizeof(name),  lp[k].opname);
+					strcpy_s(lp[k + 2].opname, OPNAME_SZ, name);
 
 					lp[k + 2].wa = BDP[i].Wa;
 					lp[k + 2].wb = BDP[i].Wb - 90.0;
@@ -248,9 +248,9 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 
 					//HOUSEN2(&lp[k+2].P[0],&lp[k+2].P[1],&lp[k+2].P[2],&lp[k+2].e) ;
 
-					strcpy(name, "4");
-					strcat(name, lp[k].opname);
-					lp[k + 3].opname = stralloc(name);
+					strcpy_s(name, sizeof(name), "4");
+					strcat_s(name, sizeof(name),  lp[k].opname);
+					strcpy_s(lp[k + 3].opname, OPNAME_SZ, name);
 
 					lp[k + 3].wa = BDP[i].Wa + 90.0;
 					if (lp[k + 3].wa >= 180.0)
@@ -284,9 +284,9 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 
 					//HOUSEN2(&lp[k+3].P[0],&lp[k+3].P[1],&lp[k+3].P[2],&lp[k+3].e) ;
 
-					strcpy(name, "5");
-					strcat(name, lp[k].opname);
-					lp[k + 4].opname = stralloc(name);
+					strcpy_s(name, sizeof(name), "5");
+					strcat_s(name, sizeof(name),  lp[k].opname);
+					strcpy_s(lp[k + 4].opname, OPNAME_SZ, name);
 
 					lp[k + 4].wa = BDP[i].Wa - 180;
 					if (lp[k + 4].wa > 180)
@@ -342,7 +342,7 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 					csWb = cos((90.0 - BDP[i].Wb)*M_rad);
 					ssWb = sin((90.0 - BDP[i].Wb)*M_rad);
 
-					lp[k].opname = stralloc(BDP[i].SBLK[j].snbname);
+					strcpy_s(lp[k].opname, OPNAME_SZ, BDP[i].SBLK[j].snbname);
 
 					lp[k].wa = BDP[i].Wa - 90.0;
 					if (lp[k].wa <= -180.0)
@@ -397,7 +397,7 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 					chWA = cos((90.0 - BDP[i].Wb)*M_rad);
 					shWA = sin((90.0 - BDP[i].Wb)*M_rad);
 
-					lp[k].opname = stralloc(BDP[i].SBLK[j].snbname);
+					strcpy_s(lp[k].opname, OPNAME_SZ, BDP[i].SBLK[j].snbname);
 
 					lp[k].wa = BDP[i].Wa - 180;
 					if (lp[k].wa > 180)
@@ -476,7 +476,7 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 			saWb = sin(obs[i].Wb*M_rad);
 			caWa = cos(-obs[i].Wa*M_rad);
 
-			lp[k].opname = stralloc(obs[i].obsname);
+			strcpy_s(lp[k].opname, OPNAME_SZ, obs[i].obsname);
 
 			lp[k].wa = obs[i].Wa;
 			lp[k].wb = obs[i].Wb;
@@ -522,7 +522,7 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 			cbWa = cos(-obs[i].Wa*M_rad);
 			sbWa = sin(-obs[i].Wa*M_rad);
 
-			lp[k].opname = stralloc(obs[i].obsname);
+			strcpy_s(lp[k].opname, OPNAME_SZ, obs[i].obsname);
 
 			lp[k].wa = obs[i].Wa;
 			lp[k].wb = 90.0;
@@ -560,9 +560,9 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 
 			//HOUSEN2(&lp[k].P[0],&lp[k].P[1],&lp[k].P[2],&lp[k].e) ;
 
-			strcpy(name, "2");
-			strcat(name, lp[k].opname);
-			lp[k + 1].opname = stralloc(name);
+			strcpy_s(name, sizeof(name), "2");
+			strcat_s(name, sizeof(name),  lp[k].opname);
+			strcpy_s(lp[k + 1].opname, OPNAME_SZ, name);
 
 			lp[k + 1].wa = obs[i].Wa - 90.0;
 			if (lp[k + 1].wa <= -180.0)
@@ -597,9 +597,9 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 			CAT(&lp[k + 1].e.X, &lp[k + 1].e.Y, &lp[k + 1].e.Z);
 			//HOUSEN2(&lp[k+1].P[0],&lp[k+1].P[1],&lp[k+1].P[2],&lp[k+1].e) ;
 
-			strcpy(name, "3");
-			strcat(name, lp[k].opname);
-			lp[k + 2].opname = stralloc(name);
+			strcpy_s(name, sizeof(name), "3");
+			strcat_s(name, sizeof(name),  lp[k].opname);
+			strcpy_s(lp[k + 2].opname, OPNAME_SZ, name);
 
 			lp[k + 2].wa = obs[i].Wa - 180.0;
 			if (lp[k + 2].wa <= -180.0)
@@ -633,9 +633,9 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 			CAT(&lp[k + 2].e.X, &lp[k + 2].e.Y, &lp[k + 2].e.Z);
 			//HOUSEN2(&lp[k+2].P[0],&lp[k+2].P[1],&lp[k+2].P[2],&lp[k+2].e) ;
 
-			strcpy(name, "4");
-			strcat(name, lp[k].opname);
-			lp[k + 3].opname = stralloc(name);
+			strcpy_s(name, sizeof(name), "4");
+			strcat_s(name, sizeof(name),  lp[k].opname);
+			strcpy_s(lp[k + 3].opname, OPNAME_SZ, name);
 
 			lp[k + 3].wa = obs[i].Wa + 90.0;
 			if (lp[k + 3].wa > 180.0)
@@ -678,7 +678,8 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 			saWb = sin(obs[i].Wb*M_rad);
 			caWa = cos(obs[i].Wa*M_rad);
 
-			strcpy(lp[k].opname, obs[i].obsname);
+			//TODO: 安全にコピーできていない。一旦freeしてメモリの確保が必要。
+			strcpy_s(lp[k].opname, OPNAME_SZ, obs[i].obsname);
 
 			lp[k].wa = obs[i].Wa;
 			lp[k].wb = obs[i].Wb;
@@ -723,7 +724,7 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 			saWb = sin(obs[i].Wb*M_rad);
 			caWa = cos(-obs[i].Wa*M_rad);
 
-			strcpy(lp[k].opname, obs[i].obsname);
+			strcpy_s(lp[k].opname, OPNAME_SZ, obs[i].obsname);
 
 			lp[k].wa = obs[i].Wa;
 			lp[k].wb = obs[i].Wb;
@@ -771,9 +772,9 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 	/*--------------------------------------------------------*/
 	for (i = 0; i < treen; i++){
 		if (strcmp(tree[i].treetype, "treeA") == 0){
-			strcpy(name, tree[i].treename);
-			strcat(name, "-m1");
-			lp[k].opname = stralloc(name);
+			strcpy_s(name, sizeof(name), tree[i].treename);
+			strcat_s(name, sizeof(name),  "-m1");
+			strcpy_s(lp[k].opname, OPNAME_SZ, name);
 
 			for (p = 0; p < 366; p++)
 				lp[k].shad[p] = 1;
@@ -815,9 +816,9 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 			/*----2----*/
 			//strcpy(lp[k].opname, tree[i].treename);
 			//strcat(lp[k].opname, "-m2");
-			strcpy(name, tree[i].treename);
-			strcat(name, "-m2");
-			lp[k].opname = stralloc(name);
+			strcpy_s(name, sizeof(name), tree[i].treename);
+			strcat_s(name, sizeof(name),  "-m2");
+			strcpy_s(lp[k].opname, OPNAME_SZ, name);
 			lp[k].wa = -90.0;
 			lp[k].wb = 90.0;
 			lp[k].ref = 0.0;
@@ -855,9 +856,9 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 			/*----3----*/
 			//strcpy(lp[k].opname, tree[i].treename);
 			//strcat(lp[k].opname, "-m3");
-			strcpy(name, tree[i].treename);
-			strcat(name, "-m3");
-			lp[k].opname = stralloc(name);
+			strcpy_s(name, sizeof(name), tree[i].treename);
+			strcat_s(name, sizeof(name),  "-m3");
+			strcpy_s(lp[k].opname, OPNAME_SZ, name);
 
 			lp[k].wa = 180.0;
 			lp[k].wb = 90.0;
@@ -896,9 +897,9 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 			/*----4----*/
 			//strcpy(lp[k].opname, tree[i].treename);
 			//strcat(lp[k].opname, "-m4");
-			strcpy(name, tree[i].treename);
-			strcat(name, "-m4");
-			lp[k].opname = stralloc(name);
+			strcpy_s(name, sizeof(name), tree[i].treename);
+			strcat_s(name, sizeof(name),  "-m4");
+			strcpy_s(lp[k].opname, OPNAME_SZ, name);
 
 			lp[k].wa = 90.0;
 			lp[k].wb = 90.0;
@@ -932,9 +933,9 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 
 			/*----5----*/
 			//strcpy(lp[k].opname, tree[i].treename);
-			strcpy(name, tree[i].treename);
-			//strcat(name, "-m2");
-			lp[k].opname = stralloc(name);
+			strcpy_s(name, sizeof(name), tree[i].treename);
+			//strcat_s(name, sizeof(name),  "-m2");
+			strcpy_s(lp[k].opname, OPNAME_SZ, name);
 
 			lp[k].wa = -22.5;
 			lp[k].ref = 0.0;
@@ -977,9 +978,9 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 
 			/*----6----*/
 			//strcpy(lp[k].opname, tree[i].treename);
-			strcpy(name, tree[i].treename);
-			//strcat(name, "-m2");
-			lp[k].opname = stralloc(name);
+			strcpy_s(name, sizeof(name), tree[i].treename);
+			//strcat_s(name, sizeof(name),  "-m2");
+			strcpy_s(lp[k].opname, OPNAME_SZ, name);
 
 			lp[k].wa = lp[k - 1].wa - 45;
 			lp[k].ref = 0.0;
@@ -1018,9 +1019,9 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 
 			/*----7----*/
 			//strcpy(lp[k].opname, tree[i].treename);
-			strcpy(name, tree[i].treename);
-			//strcat(name, "-m2");
-			lp[k].opname = stralloc(name);
+			strcpy_s(name, sizeof(name), tree[i].treename);
+			//strcat_s(name, sizeof(name),  "-m2");
+			strcpy_s(lp[k].opname, OPNAME_SZ, name);
 
 			lp[k].wa = lp[k - 1].wa - 45;
 			lp[k].ref = 0.0;
@@ -1058,9 +1059,9 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 
 			/*----8----*/
 			//strcpy(lp[k].opname, tree[i].treename);
-			strcpy(name, tree[i].treename);
-			//strcat(name, "-m2");
-			lp[k].opname = stralloc(name);
+			strcpy_s(name, sizeof(name), tree[i].treename);
+			//strcat_s(name, sizeof(name),  "-m2");
+			strcpy_s(lp[k].opname, OPNAME_SZ, name);
 
 			lp[k].wa = lp[k - 1].wa - 45;
 			lp[k].ref = 0.0;
@@ -1098,9 +1099,9 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 
 			/*----9----*/
 			//strcpy(lp[k].opname, tree[i].treename);
-			strcpy(name, tree[i].treename);
-			//strcat(name, "-m2");
-			lp[k].opname = stralloc(name);
+			strcpy_s(name, sizeof(name), tree[i].treename);
+			//strcat_s(name, sizeof(name),  "-m2");
+			strcpy_s(lp[k].opname, OPNAME_SZ, name);
 
 			lp[k].wa = 360 + (lp[k - 1].wa - 45);
 			lp[k].ref = 0.0;
@@ -1138,9 +1139,9 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 
 			/*----10----*/
 			//strcpy(lp[k].opname, tree[i].treename);
-			strcpy(name, tree[i].treename);
-			//strcat(name, "-m2");
-			lp[k].opname = stralloc(name);
+			strcpy_s(name, sizeof(name), tree[i].treename);
+			//strcat_s(name, sizeof(name),  "-m2");
+			strcpy_s(lp[k].opname, OPNAME_SZ, name);
 
 			lp[k].wa = lp[k - 1].wa - 45;
 			lp[k].ref = 0.0;
@@ -1178,9 +1179,9 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 
 			/*----11----*/
 			//strcpy(lp[k].opname, tree[i].treename);
-			strcpy(name, tree[i].treename);
-			//strcat(name, "-m2");
-			lp[k].opname = stralloc(name);
+			strcpy_s(name, sizeof(name), tree[i].treename);
+			//strcat_s(name, sizeof(name),  "-m2");
+			strcpy_s(lp[k].opname, OPNAME_SZ, name);
 
 			lp[k].wa = lp[k - 1].wa - 45;
 			lp[k].ref = 0.0;
@@ -1218,8 +1219,8 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 
 			/*----12----*/
 			//strcpy(lp[k].opname, tree[i].treename);
-			strcpy(name, tree[i].treename);
-			lp[k].opname = stralloc(name);
+			strcpy_s(name, sizeof(name), tree[i].treename);
+			strcpy_s(lp[k].opname, OPNAME_SZ, name);
 
 			lp[k].wa = lp[k - 1].wa - 45;
 			lp[k].ref = 0.0;
@@ -1257,8 +1258,8 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 
 			/*----13----*/
 			//strcpy(lp[k].opname, tree[i].treename);
-			strcpy(name, tree[i].treename);
-			lp[k].opname = stralloc(name);
+			strcpy_s(name, sizeof(name), tree[i].treename);
+			strcpy_s(lp[k].opname, OPNAME_SZ, name);
 
 			lp[k].wa = -22.5;
 			lp[k].ref = 0.0;
@@ -1300,8 +1301,8 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 
 			/*----14----*/
 			//strcpy(lp[k].opname, tree[i].treename);
-			strcpy(name, tree[i].treename);
-			lp[k].opname = stralloc(name);
+			strcpy_s(name, sizeof(name), tree[i].treename);
+			strcpy_s(lp[k].opname, OPNAME_SZ, name);
 
 			lp[k].wa = lp[k - 1].wa - 45;
 			lp[k].ref = 0.0;
@@ -1339,8 +1340,8 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 
 			/*----15----*/
 			//strcpy(lp[k].opname, tree[i].treename);
-			strcpy(name, tree[i].treename);
-			lp[k].opname = stralloc(name);
+			strcpy_s(name, sizeof(name), tree[i].treename);
+			strcpy_s(lp[k].opname, OPNAME_SZ, name);
 
 			lp[k].wa = lp[k - 1].wa - 45;
 			lp[k].ref = 0.0;
@@ -1378,8 +1379,8 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 
 			/*----16----*/
 			//strcpy(lp[k].opname, tree[i].treename);
-			strcpy(name, tree[i].treename);
-			lp[k].opname = stralloc(name);
+			strcpy_s(name, sizeof(name), tree[i].treename);
+			strcpy_s(lp[k].opname, OPNAME_SZ, name);
 
 			lp[k].wa = lp[k - 1].wa - 45;
 			lp[k].ref = 0.0;
@@ -1417,8 +1418,8 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 
 			/*---17---*/
 			//strcpy(lp[k].opname, tree[i].treename);
-			strcpy(name, tree[i].treename);
-			lp[k].opname = stralloc(name);
+			strcpy_s(name, sizeof(name), tree[i].treename);
+			strcpy_s(lp[k].opname, OPNAME_SZ, name);
 
 			lp[k].wa = 360 + (lp[k - 1].wa - 45);
 			lp[k].ref = 0.0;
@@ -1457,8 +1458,8 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 
 			/*----18----*/
 			//strcpy(lp[k].opname, tree[i].treename);
-			strcpy(name, tree[i].treename);
-			lp[k].opname = stralloc(name);
+			strcpy_s(name, sizeof(name), tree[i].treename);
+			strcpy_s(lp[k].opname, OPNAME_SZ, name);
 
 			lp[k].wa = lp[k - 1].wa - 45;
 			lp[k].ref = 0.0;
@@ -1496,8 +1497,8 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 
 			/*---19----*/
 			//strcpy(lp[k].opname, tree[i].treename);
-			strcpy(name, tree[i].treename);
-			lp[k].opname = stralloc(name);
+			strcpy_s(name, sizeof(name), tree[i].treename);
+			strcpy_s(lp[k].opname, OPNAME_SZ, name);
 
 			lp[k].wa = lp[k - 1].wa - 45;
 			lp[k].ref = 0.0;
@@ -1535,8 +1536,8 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 
 			/*---20----*/
 			//strcpy(lp[k].opname, tree[i].treename);
-			strcpy(name, tree[i].treename);
-			lp[k].opname = stralloc(name);
+			strcpy_s(name, sizeof(name), tree[i].treename);
+			strcpy_s(lp[k].opname, OPNAME_SZ, name);
 
 			lp[k].wa = lp[k - 1].wa - 45;
 			lp[k].ref = 0.0;
@@ -1586,7 +1587,7 @@ void LP_COORDNT(int *lpn, int bdpn, int obsn, int treen, int polyn,
 	for (i = 0; i < polyn; i++){
 
 		if (strcmp(poly[i].polyknd, "OBS") == 0){
-			lp[k].opname = stralloc(poly[i].polyname);
+			strcpy_s(lp[k].opname, OPNAME_SZ, poly[i].polyname);
 
 			lp[k].polyd = poly[i].polyd;
 			lp[k].P = (XYZ *)malloc(sizeof(XYZ)*lp[k].polyd);
@@ -1655,7 +1656,7 @@ void OP_COORDNT(int *opn, int bdpn, BBDP *BDP, P_MENN *op, int polyn, POLYGN *po
 			op[j].wlflg = 0;
 
 
-			op[j].opname = stralloc(BDP[l].RMP[k].rmpname);
+			strcpy_s(op[j].opname, OPNAME_SZ, BDP[l].RMP[k].rmpname);
 
 			op[j].rgb[0] = BDP[l].RMP[k].rgb[0];
 			op[j].rgb[1] = BDP[l].RMP[k].rgb[1];
@@ -1751,7 +1752,7 @@ void OP_COORDNT(int *opn, int bdpn, BBDP *BDP, P_MENN *op, int polyn, POLYGN *po
 	for (i = 0; i < polyn; i++){
 		if (strcmp(poly[i].polyknd, "RMP") == 0){
 
-			op[sumop].opname = stralloc(poly[i].polyname);
+			strcpy_s(op[sumop].opname, OPNAME_SZ, poly[i].polyname);
 			op[sumop].ref = poly[i].ref;
 			op[sumop].wd = 0;
 			op[sumop].grpx = poly[i].grpx;

--- a/Source/func/DAINYUU.c
+++ b/Source/func/DAINYUU.c
@@ -19,7 +19,7 @@
 					  FILE=DAINYUU.c
 					  Create Date=1999.6.7
 					  */
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include <math.h>
 #include <string.h>
@@ -42,7 +42,8 @@ void DAINYUU_MP(P_MENN *mp, P_MENN *op, int opn, int mpn){
 		mp[k].sbflg = 0;
 		mp[k].wlflg = 0;
 
-		strcpy(mp[k].opname, op[i].opname);
+		strcpy_s(mp[k].opname, OPNAME_SZ, op[i].opname);
+
 		for (j = 0; j < op[i].wd; j++){
 			k++;
 
@@ -66,7 +67,8 @@ void DAINYUU_MP(P_MENN *mp, P_MENN *op, int opn, int mpn){
 			mp[k].wa = op[i].wa;
 			mp[k].e = op[i].e;
 
-			mp[k].opname = stralloc(op[i].opw[j].opwname);
+			strcpy_s(mp[k].opname, OPNAME_SZ, op[i].opw[j].opwname);
+
 			for (l = 0; l < mp[k].polyd; l++){
 				mp[k].P[l] = op[i].opw[j].P[l];
 			}

--- a/Source/func/DATAIN.c
+++ b/Source/func/DATAIN.c
@@ -13,7 +13,7 @@
 //You should have received a copy of the GNU General Public License
 //along with Foobar.If not, see < https://www.gnu.org/licenses/>.
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -37,7 +37,7 @@ char NAME[SCHAR];
 
 void HISASHI(FILE *fi, sunblk *sb){
 
-	fscanf(fi, "%s", NAME);
+	fscanf_s(fi, "%s", NAME, sizeof(NAME));
 	sb->snbname = stralloc(NAME);
 
 	/*-色の初期値--*/
@@ -45,26 +45,27 @@ void HISASHI(FILE *fi, sunblk *sb){
 	sb->rgb[1] = 0.2;
 	sb->rgb[2] = 0.0;
 
-	while (fscanf(fi, "%s", NAME), NAME[0] != ';'){
+	// ex) 1Fhisa -xy 0 2.7 -DW 0.5 8.645 -a 90 ;
+	while (fscanf_s(fi, "%s", NAME, sizeof(NAME)), NAME[0] != ';'){
 
 		if (strcmp(NAME, "-xy") == 0){
-			fscanf(fi, "%lf", &sb->x);
-			fscanf(fi, "%lf", &sb->y);
+			fscanf_s(fi, "%lf", &sb->x);
+			fscanf_s(fi, "%lf", &sb->y);
 		}
 
 		else if (strcmp(NAME, "-DW") == 0){
-			fscanf(fi, "%lf", &sb->D);
-			fscanf(fi, "%lf", &sb->W);
+			fscanf_s(fi, "%lf", &sb->D);
+			fscanf_s(fi, "%lf", &sb->W);
 		}
 
 		else if (strcmp(NAME, "-a") == 0)
-			fscanf(fi, "%lf", &sb->WA);
+			fscanf_s(fi, "%lf", &sb->WA);
 
 
 		else if (strcmp(NAME, "-rgb") == 0){
-			fscanf(fi, "%lf", &sb->rgb[0]);
-			fscanf(fi, "%lf", &sb->rgb[1]);
-			fscanf(fi, "%lf", &sb->rgb[2]);
+			fscanf_s(fi, "%lf", &sb->rgb[0]);
+			fscanf_s(fi, "%lf", &sb->rgb[1]);
+			fscanf_s(fi, "%lf", &sb->rgb[2]);
 		}
 
 		else {
@@ -85,30 +86,30 @@ void BARUKO(FILE *fi, sunblk *sb){
 	sb->rgb[2] = 0.0;
 
 
-	fscanf(fi, "%s", NAME);
+	fscanf_s(fi, "%s", NAME, sizeof(NAME));
 	sb->snbname = stralloc(NAME);
 
-	while (fscanf(fi, "%s", NAME), NAME[0] != ';'){
+	while (fscanf_s(fi, "%s", NAME, sizeof(NAME)), NAME[0] != ';'){
 
 		if (strcmp(NAME, "-xy") == 0){
-			fscanf(fi, "%lf", &sb->x);
-			fscanf(fi, "%lf", &sb->y);
+			fscanf_s(fi, "%lf", &sb->x);
+			fscanf_s(fi, "%lf", &sb->y);
 		}
 
 		else if (strcmp(NAME, "-DHWh") == 0){
-			fscanf(fi, "%lf", &sb->D);
-			fscanf(fi, "%lf", &sb->H);
-			fscanf(fi, "%lf", &sb->W);
-			fscanf(fi, "%lf", &sb->h);
+			fscanf_s(fi, "%lf", &sb->D);
+			fscanf_s(fi, "%lf", &sb->H);
+			fscanf_s(fi, "%lf", &sb->W);
+			fscanf_s(fi, "%lf", &sb->h);
 		}
 
 		else if (strcmp(NAME, "-ref") == 0)
-			fscanf(fi, "%lf", &sb->ref);
+			fscanf_s(fi, "%lf", &sb->ref);
 
 		else if (strcmp(NAME, "-rgb") == 0){
-			fscanf(fi, "%lf", &sb->rgb[0]);
-			fscanf(fi, "%lf", &sb->rgb[1]);
-			fscanf(fi, "%lf", &sb->rgb[2]);
+			fscanf_s(fi, "%lf", &sb->rgb[0]);
+			fscanf_s(fi, "%lf", &sb->rgb[1]);
+			fscanf_s(fi, "%lf", &sb->rgb[2]);
 		}
 
 		else {
@@ -126,28 +127,28 @@ void SODEK(FILE *fi, sunblk *sb){
 	sb->rgb[1] = 0.2;
 	sb->rgb[2] = 0.0;
 
-	fscanf(fi, "%s", NAME);
+	fscanf_s(fi, "%s", NAME, sizeof(NAME));
 	sb->snbname = stralloc(NAME);
 
-	while (fscanf(fi, "%s", NAME), NAME[0] != ';'){
+	while (fscanf_s(fi, "%s", NAME, sizeof(NAME)), NAME[0] != ';'){
 
 		if (strcmp(NAME, "-xy") == 0){
-			fscanf(fi, "%lf", &sb->x);
-			fscanf(fi, "%lf", &sb->y);
+			fscanf_s(fi, "%lf", &sb->x);
+			fscanf_s(fi, "%lf", &sb->y);
 		}
 
 		else if (strcmp(NAME, "-DH") == 0){
-			fscanf(fi, "%lf", &sb->D);
-			fscanf(fi, "%lf", &sb->H);
+			fscanf_s(fi, "%lf", &sb->D);
+			fscanf_s(fi, "%lf", &sb->H);
 		}
 
 		else if (strcmp(NAME, "-a") == 0)
-			fscanf(fi, "%lf", &sb->WA);
+			fscanf_s(fi, "%lf", &sb->WA);
 
 		else if (strcmp(NAME, "-rgb") == 0){
-			fscanf(fi, "%lf", &sb->rgb[0]);
-			fscanf(fi, "%lf", &sb->rgb[1]);
-			fscanf(fi, "%lf", &sb->rgb[2]);
+			fscanf_s(fi, "%lf", &sb->rgb[0]);
+			fscanf_s(fi, "%lf", &sb->rgb[1]);
+			fscanf_s(fi, "%lf", &sb->rgb[2]);
 		}
 		else {
 			printf("ERROR parameter----SODEKABE: %s\n", NAME);
@@ -165,26 +166,26 @@ void SCREEN(FILE *fi, sunblk *sb){
 	sb->rgb[1] = 0.2;
 	sb->rgb[2] = 0.0;
 
-	fscanf(fi, "%s", NAME);
+	fscanf_s(fi, "%s", NAME, sizeof(NAME));
 	sb->snbname = stralloc(NAME);
 
-	while (fscanf(fi, "%s", NAME), NAME[0] != ';'){
+	while (fscanf_s(fi, "%s", NAME, sizeof(NAME)), NAME[0] != ';'){
 
 		if (strcmp(NAME, "-xy") == 0){
-			fscanf(fi, "%lf", &sb->x);
-			fscanf(fi, "%lf", &sb->y);
+			fscanf_s(fi, "%lf", &sb->x);
+			fscanf_s(fi, "%lf", &sb->y);
 		}
 
 		else if (strcmp(NAME, "-DHW") == 0){
-			fscanf(fi, "%lf", &sb->D);
-			fscanf(fi, "%lf", &sb->H);
-			fscanf(fi, "%lf", &sb->W);
+			fscanf_s(fi, "%lf", &sb->D);
+			fscanf_s(fi, "%lf", &sb->H);
+			fscanf_s(fi, "%lf", &sb->W);
 		}
 
 		else if (strcmp(NAME, "-rgb") == 0){
-			fscanf(fi, "%lf", &sb->rgb[0]);
-			fscanf(fi, "%lf", &sb->rgb[1]);
-			fscanf(fi, "%lf", &sb->rgb[2]);
+			fscanf_s(fi, "%lf", &sb->rgb[0]);
+			fscanf_s(fi, "%lf", &sb->rgb[1]);
+			fscanf_s(fi, "%lf", &sb->rgb[2]);
 		}
 
 		else {
@@ -205,36 +206,36 @@ void rmpdata(FILE *fi, RRMP *rp, MADO *wp){
 	rp->rgb[1] = 0.9;
 	rp->rgb[2] = 0.9;
 
-	fscanf(fi, "%s", NAME);
+	fscanf_s(fi, "%s", NAME, sizeof(NAME));
 	//printf("<rmpdata> 1 NAME=%s\n", NAME);
 	rp->rmpname = stralloc(NAME);
-	fscanf(fi, "%s", NAME);
+	fscanf_s(fi, "%s", NAME, sizeof(NAME));
 	//printf("<rmpdata> 2 NAME=%s\n", NAME);
 	rp->wallname = stralloc(NAME);
 
-	while (fscanf(fi, "%s", NAME), NAME[0] != ';'){
+	while (fscanf_s(fi, "%s", NAME, sizeof(NAME)), NAME[0] != ';'){
 
 		//printf("<rmpdata> 3 NAME=%s\n", NAME);
 		if (strcmp(NAME, "-xyb") == 0){
-			fscanf(fi, "%lf", &rp->xb0);
-			fscanf(fi, "%lf", &rp->yb0);
+			fscanf_s(fi, "%lf", &rp->xb0);
+			fscanf_s(fi, "%lf", &rp->yb0);
 		}
 
 		else if (strcmp(NAME, "-WH") == 0){
-			fscanf(fi, "%lf", &rp->Rw);
-			fscanf(fi, "%lf", &rp->Rh);
+			fscanf_s(fi, "%lf", &rp->Rw);
+			fscanf_s(fi, "%lf", &rp->Rh);
 		}
 
 		else if (strcmp(NAME, "-ref") == 0)
-			fscanf(fi, "%lf", &rp->ref);
+			fscanf_s(fi, "%lf", &rp->ref);
 
 		else if (strcmp(NAME, "-grpx") == 0)
-			fscanf(fi, "%lf", &rp->grpx);
+			fscanf_s(fi, "%lf", &rp->grpx);
 
 		else if (strcmp(NAME, "-rgb") == 0){
-			fscanf(fi, "%lf", &rp->rgb[0]);
-			fscanf(fi, "%lf", &rp->rgb[1]);
-			fscanf(fi, "%lf", &rp->rgb[2]);
+			fscanf_s(fi, "%lf", &rp->rgb[0]);
+			fscanf_s(fi, "%lf", &rp->rgb[1]);
+			fscanf_s(fi, "%lf", &rp->rgb[2]);
 		}
 
 		else {
@@ -247,7 +248,7 @@ void rmpdata(FILE *fi, RRMP *rp, MADO *wp){
 
 	rp->sumWD = 0;
 	//wp = rp->WD;
-	while (fscanf(fi, "%s", NAME), NAME[0] != ';'){
+	while (fscanf_s(fi, "%s", NAME, sizeof(NAME)), NAME[0] != ';'){
 
 		//printf("<rmpdata> 4 NAME=%s\n", NAME);
 		wp->ref = 0.0;
@@ -266,33 +267,33 @@ void rmpdata(FILE *fi, RRMP *rp, MADO *wp){
 
 		rp->sumWD = rp->sumWD + 1;
 
-		fscanf(fi, "%s", NAME);
+		fscanf_s(fi, "%s", NAME, sizeof(NAME));
 		//printf("<rmpdata> 5 NAME=%s\n", NAME);
 		wp->winname = stralloc(NAME);
 
-		while (fscanf(fi, "%s", NAME), NAME[0] != ';'){
+		while (fscanf_s(fi, "%s", NAME, sizeof(NAME)), NAME[0] != ';'){
 
 			//printf("<rmpdata> 6 NAME=%s\n", NAME);
 			if (strcmp(NAME, "-xyr") == 0){
-				fscanf(fi, "%lf", &wp->xr);
-				fscanf(fi, "%lf", &wp->yr);
+				fscanf_s(fi, "%lf", &wp->xr);
+				fscanf_s(fi, "%lf", &wp->yr);
 			}
 
 			else if (strcmp(NAME, "-WH") == 0){
-				fscanf(fi, "%lf", &wp->Ww);
-				fscanf(fi, "%lf", &wp->Wh);
+				fscanf_s(fi, "%lf", &wp->Ww);
+				fscanf_s(fi, "%lf", &wp->Wh);
 			}
 
 			else if (strcmp(NAME, "-ref") == 0)
-				fscanf(fi, "%lf", &wp->ref);
+				fscanf_s(fi, "%lf", &wp->ref);
 
 			else if (strcmp(NAME, "-grpx") == 0)
-				fscanf(fi, "%lf", &wp->grpx);
+				fscanf_s(fi, "%lf", &wp->grpx);
 
 			else if (strcmp(NAME, "-rgb") == 0){
-				fscanf(fi, "%lf", &wp->rgb[0]);
-				fscanf(fi, "%lf", &wp->rgb[1]);
-				fscanf(fi, "%lf", &wp->rgb[2]);
+				fscanf_s(fi, "%lf", &wp->rgb[0]);
+				fscanf_s(fi, "%lf", &wp->rgb[1]);
+				fscanf_s(fi, "%lf", &wp->rgb[2]);
 			}
 
 			else {
@@ -314,34 +315,34 @@ void rectdata(FILE *fi, OBS *obs){
 	obs->rgb[1] = 0.7;
 	obs->rgb[2] = 0.7;
 
-	fscanf(fi, "%s", NAME);
+	fscanf_s(fi, "%s", NAME, sizeof(NAME));
 	obs->obsname = stralloc(NAME);
 
-	while (fscanf(fi, "%s", NAME), NAME[0] != ';'){
+	while (fscanf_s(fi, "%s", NAME, sizeof(NAME)), NAME[0] != ';'){
 
 		if (strcmp(NAME, "-xyz") == 0){
-			fscanf(fi, "%lf", &obs->x);
-			fscanf(fi, "%lf", &obs->y);
-			fscanf(fi, "%lf", &obs->z);
+			fscanf_s(fi, "%lf", &obs->x);
+			fscanf_s(fi, "%lf", &obs->y);
+			fscanf_s(fi, "%lf", &obs->z);
 		}
 
 		else if (strcmp(NAME, "-WH") == 0){
-			fscanf(fi, "%lf", &obs->W);
-			fscanf(fi, "%lf", &obs->H);
+			fscanf_s(fi, "%lf", &obs->W);
+			fscanf_s(fi, "%lf", &obs->H);
 		}
 
 		else if (strcmp(NAME, "-WaWb") == 0){
-			fscanf(fi, "%lf", &obs->Wa);
-			fscanf(fi, "%lf", &obs->Wb);
+			fscanf_s(fi, "%lf", &obs->Wa);
+			fscanf_s(fi, "%lf", &obs->Wb);
 		}
 
 		else if (strcmp(NAME, "-ref") == 0)
-			fscanf(fi, "%lf", &obs->ref[0]);
+			fscanf_s(fi, "%lf", &obs->ref[0]);
 
 		else if (strcmp(NAME, "-rgb") == 0){
-			fscanf(fi, "%lf", &obs->rgb[0]);
-			fscanf(fi, "%lf", &obs->rgb[1]);
-			fscanf(fi, "%lf", &obs->rgb[2]);
+			fscanf_s(fi, "%lf", &obs->rgb[0]);
+			fscanf_s(fi, "%lf", &obs->rgb[1]);
+			fscanf_s(fi, "%lf", &obs->rgb[2]);
 		}
 
 		else {
@@ -364,42 +365,42 @@ void cubdata(FILE *fi, OBS *obs){
 	obs->rgb[1] = 0.7;
 	obs->rgb[2] = 0.7;
 
-	fscanf(fi, "%s", NAME);
+	fscanf_s(fi, "%s", NAME, sizeof(NAME));
 	obs->obsname = stralloc(NAME);
 
-	while (fscanf(fi, "%s", NAME), NAME[0] != ';'){
+	while (fscanf_s(fi, "%s", NAME, sizeof(NAME)), NAME[0] != ';'){
 
 		if (strcmp(NAME, "-xyz") == 0){
-			fscanf(fi, "%lf", &obs->x);
-			fscanf(fi, "%lf", &obs->y);
-			fscanf(fi, "%lf", &obs->z);
+			fscanf_s(fi, "%lf", &obs->x);
+			fscanf_s(fi, "%lf", &obs->y);
+			fscanf_s(fi, "%lf", &obs->z);
 		}
 
 		else if (strcmp(NAME, "-WDH") == 0){
-			fscanf(fi, "%lf", &obs->W);
-			fscanf(fi, "%lf", &obs->D);
-			fscanf(fi, "%lf", &obs->H);
+			fscanf_s(fi, "%lf", &obs->W);
+			fscanf_s(fi, "%lf", &obs->D);
+			fscanf_s(fi, "%lf", &obs->H);
 		}
 
 		else if (strcmp(NAME, "-Wa") == 0)
-			fscanf(fi, "%lf", &obs->Wa);
+			fscanf_s(fi, "%lf", &obs->Wa);
 
 		else if (strcmp(NAME, "-ref0") == 0)
-			fscanf(fi, "%lf", &obs->ref[0]);
+			fscanf_s(fi, "%lf", &obs->ref[0]);
 
 		else if (strcmp(NAME, "-ref1") == 0)
-			fscanf(fi, "%lf", &obs->ref[1]);
+			fscanf_s(fi, "%lf", &obs->ref[1]);
 
 		else if (strcmp(NAME, "-ref2") == 0)
-			fscanf(fi, "%lf", &obs->ref[2]);
+			fscanf_s(fi, "%lf", &obs->ref[2]);
 
 		else if (strcmp(NAME, "-ref3") == 0)
-			fscanf(fi, "%lf", &obs->ref[3]);
+			fscanf_s(fi, "%lf", &obs->ref[3]);
 
 		else if (strcmp(NAME, "-rgb") == 0){
-			fscanf(fi, "%lf", &obs->rgb[0]);
-			fscanf(fi, "%lf", &obs->rgb[1]);
-			fscanf(fi, "%lf", &obs->rgb[2]);
+			fscanf_s(fi, "%lf", &obs->rgb[0]);
+			fscanf_s(fi, "%lf", &obs->rgb[1]);
+			fscanf_s(fi, "%lf", &obs->rgb[2]);
 		}
 
 		else {
@@ -419,33 +420,34 @@ void tridata(FILE *fi, OBS *obs){
 	obs->rgb[1] = 0.7;
 	obs->rgb[2] = 0.7;
 
-	fscanf(fi, "%s", obs->obsname);
+	fscanf_s(fi, "%s", NAME, sizeof(NAME));
+	obs->obsname = stralloc(NAME);
 
-	while (fscanf(fi, "%s", NAME), NAME[0] != ';'){
+	while (fscanf_s(fi, "%s", NAME, sizeof(NAME)), NAME[0] != ';'){
 
 		if (strcmp(NAME, "-xyz") == 0){
-			fscanf(fi, "%lf", &obs->x);
-			fscanf(fi, "%lf", &obs->y);
-			fscanf(fi, "%lf", &obs->z);
+			fscanf_s(fi, "%lf", &obs->x);
+			fscanf_s(fi, "%lf", &obs->y);
+			fscanf_s(fi, "%lf", &obs->z);
 		}
 
 		else if (strcmp(NAME, "-WH") == 0){
-			fscanf(fi, "%lf", &obs->W);
-			fscanf(fi, "%lf", &obs->H);
+			fscanf_s(fi, "%lf", &obs->W);
+			fscanf_s(fi, "%lf", &obs->H);
 		}
 
 		else if (strcmp(NAME, "-WaWb") == 0){
-			fscanf(fi, "%lf", &obs->Wa);
-			fscanf(fi, "%lf", &obs->Wb);
+			fscanf_s(fi, "%lf", &obs->Wa);
+			fscanf_s(fi, "%lf", &obs->Wb);
 		}
 
 		else if (strcmp(NAME, "-ref") == 0)
-			fscanf(fi, "%lf", &obs->ref[0]);
+			fscanf_s(fi, "%lf", &obs->ref[0]);
 
 		else if (strcmp(NAME, "-rgb") == 0){
-			fscanf(fi, "%lf", &obs->rgb[0]);
-			fscanf(fi, "%lf", &obs->rgb[1]);
-			fscanf(fi, "%lf", &obs->rgb[2]);
+			fscanf_s(fi, "%lf", &obs->rgb[0]);
+			fscanf_s(fi, "%lf", &obs->rgb[1]);
+			fscanf_s(fi, "%lf", &obs->rgb[2]);
 		}
 
 		else {
@@ -465,15 +467,15 @@ void dividdata(FILE *fi, int *monten, double *DE) {
 	//	exit(1);
 	//}
 
-	while (fscanf(fi, "%s", NAME), NAME[0] != ';') {
+	while (fscanf_s(fi, "%s", NAME, sizeof(NAME)), NAME[0] != ';') {
 
 		if (strcmp(NAME, "DE") == 0) {
 			//printf("Name=%s\n", NAME);
-			fscanf(fi, "%lf", DE);
+			fscanf_s(fi, "%lf", DE);
 		}
-		else if (strcmp(NAME, "MONT") == 0)
-			fscanf(fi, "%d", monten);
-
+		else if (strcmp(NAME, "MONT") == 0) {
+			fscanf_s(fi, "%d", monten);
+		}
 		else {
 			printf("ERROR parameter----DIVID: %s\n", NAME);
 			preexit();
@@ -482,7 +484,7 @@ void dividdata(FILE *fi, int *monten, double *DE) {
 
 	}
 
-	fscanf(fi, "%s", NAME);
+	fscanf_s(fi, "%s", NAME, sizeof(NAME));
 
 }
 void treedata(FILE *fi, int *treen, TREE **tree){
@@ -511,40 +513,40 @@ void treedata(FILE *fi, int *treen, TREE **tree){
 	*treen = 0;
 	tred = *tree;
 
-	while (fscanf(fi, "%s", NAME), NAME[0] != '*'){
+	while (fscanf_s(fi, "%s", NAME, sizeof(NAME)), NAME[0] != '*'){
 
 		tred->treetype = stralloc(NAME);
 
-		fscanf(fi, "%s", NAME);
+		fscanf_s(fi, "%s", NAME, sizeof(NAME));
 		tred->treename = stralloc(NAME);
 
 
 		if (strcmp(tred->treetype, "treeA") == 0){
-			while (fscanf(fi, "%s", NAME), NAME[0] != ';'){
+			while (fscanf_s(fi, "%s", NAME, sizeof(NAME)), NAME[0] != ';'){
 
 				if (strcmp(NAME, "-xyz") == 0){
-					fscanf(fi, "%lf", &tred->x);
-					fscanf(fi, "%lf", &tred->y);
-					fscanf(fi, "%lf", &tred->z);
+					fscanf_s(fi, "%lf", &tred->x);
+					fscanf_s(fi, "%lf", &tred->y);
+					fscanf_s(fi, "%lf", &tred->z);
 				}
 
 				else if (strcmp(NAME, "-WH1") == 0){
-					fscanf(fi, "%lf", &tred->W1);
-					fscanf(fi, "%lf", &tred->H1);
+					fscanf_s(fi, "%lf", &tred->W1);
+					fscanf_s(fi, "%lf", &tred->H1);
 				}
 
 				else if (strcmp(NAME, "-WH2") == 0){
-					fscanf(fi, "%lf", &tred->W2);
-					fscanf(fi, "%lf", &tred->H2);
+					fscanf_s(fi, "%lf", &tred->W2);
+					fscanf_s(fi, "%lf", &tred->H2);
 				}
 
 				else if (strcmp(NAME, "-WH3") == 0){
-					fscanf(fi, "%lf", &tred->W3);
-					fscanf(fi, "%lf", &tred->H3);
+					fscanf_s(fi, "%lf", &tred->W3);
+					fscanf_s(fi, "%lf", &tred->H3);
 				}
 
 				else if (strcmp(NAME, "-W4") == 0)
-					fscanf(fi, "%lf", &tred->W4);
+					fscanf_s(fi, "%lf", &tred->W4);
 
 				else {
 					printf("ERROR parameter----TREE: %s %s\n", tred->treename, NAME);
@@ -601,7 +603,7 @@ void polydata(FILE *fi, int *polyn, POLYGN **poly){
 
 	*polyn = 0;
 	polyp = *poly;
-	while (fscanf(fi, "%s", NAME), NAME[0] != '*'){
+	while (fscanf_s(fi, "%s", NAME, sizeof(NAME)), NAME[0] != '*'){
 
 		polyp->grpx = 1.0;
 
@@ -609,7 +611,7 @@ void polydata(FILE *fi, int *polyn, POLYGN **poly){
 		polyp->rgb[1] = 0.9;
 		polyp->rgb[2] = 0.9;
 
-		strcpy(polyp->polyknd, NAME);
+		strcpy_s(polyp->polyknd, sizeof(polyp->polyknd), NAME);
 		if ((strcmp(polyp->polyknd, "RMP") != 0) && (strcmp(polyp->polyknd, "OBS") != 0)){
 			printf("ERROR parameter----POLYGON: %s  <RMP> or <OBS> \n", polyp->polyknd);
 			//getch();
@@ -617,37 +619,37 @@ void polydata(FILE *fi, int *polyn, POLYGN **poly){
 			exit(1);
 		}
 
-		fscanf(fi, "%d", &polyp->polyd);
+		fscanf_s(fi, "%d", &polyp->polyd);
 		polyp->P = (XYZ *)malloc(sizeof(XYZ)*polyp->polyd);
 
-		fscanf(fi, "%s", NAME);
+		fscanf_s(fi, "%s", NAME, sizeof(NAME));
 		polyp->polyname = stralloc(NAME);
-		fscanf(fi, "%s", NAME);
+		fscanf_s(fi, "%s", NAME, sizeof(NAME));
 		polyp->wallname = stralloc(NAME);
 
-		while (fscanf(fi, "%s", NAME), NAME[0] != ';'){
+		while (fscanf_s(fi, "%s", NAME, sizeof(NAME)), NAME[0] != ';'){
 			if (strcmp(NAME, "-xyz") == 0){
 				for (i = 0; i < polyp->polyd; i++){
-					fscanf(fi, "%lf", &polyp->P[i].X);
-					fscanf(fi, "%lf", &polyp->P[i].Y);
-					fscanf(fi, "%lf", &polyp->P[i].Z);
+					fscanf_s(fi, "%lf", &polyp->P[i].X);
+					fscanf_s(fi, "%lf", &polyp->P[i].Y);
+					fscanf_s(fi, "%lf", &polyp->P[i].Z);
 				}
 			}
 
 			else if (strcmp(NAME, "-rgb") == 0){
-				fscanf(fi, "%lf", &polyp->rgb[0]);
-				fscanf(fi, "%lf", &polyp->rgb[1]);
-				fscanf(fi, "%lf", &polyp->rgb[2]);
+				fscanf_s(fi, "%lf", &polyp->rgb[0]);
+				fscanf_s(fi, "%lf", &polyp->rgb[1]);
+				fscanf_s(fi, "%lf", &polyp->rgb[2]);
 			}
 
 			else if (strcmp(NAME, "-ref") == 0)
-				fscanf(fi, "%lf", &polyp->ref);
+				fscanf_s(fi, "%lf", &polyp->ref);
 
 			else if (strcmp(NAME, "-refg") == 0)
-				fscanf(fi, "%lf", &polyp->refg);
+				fscanf_s(fi, "%lf", &polyp->refg);
 
 			else if (strcmp(NAME, "-grpx") == 0)
-				fscanf(fi, "%lf", &polyp->grpx);
+				fscanf_s(fi, "%lf", &polyp->grpx);
 
 			else{
 				printf("ERROR parameter----POLYGON: %s\n", NAME);
@@ -703,7 +705,8 @@ void bdpdata(FILE *fi, int *bdpn, BBDP **bp,EXSFS *Exsf){
 
 	*bdpn = 0;
 
-	while (fscanf(fi, "%s", NAME), NAME[0] != '*'){
+	// ex) BDP south -xyz 0.0 0.0 0.0 -WA 0.0 -WB 90.0 -WH 8.645 5.400 ;
+	while (fscanf_s(fi, "%s", NAME, sizeof(NAME)), NAME[0] != '*'){
 		//printf("<bdpdata> 1 NAME=%s", NAME);
 		if (strcmp(NAME, "BDP") != 0){
 			printf("error BDP\n");
@@ -711,33 +714,33 @@ void bdpdata(FILE *fi, int *bdpn, BBDP **bp,EXSFS *Exsf){
 		}
 		//printf("<bdpdata> 2 NAME=%s", NAME);
 
-		fscanf(fi, "%s", NAME);
+		fscanf_s(fi, "%s", NAME, sizeof(NAME));
 		bbdp->bdpname = stralloc(NAME);
 		//printf("<bdpdata> 3 NAME=%s", NAME);
 
-		while (fscanf(fi, "%s", NAME), NAME[0] != ';'){
+		while (fscanf_s(fi, "%s", NAME, sizeof(NAME)), NAME[0] != ';'){
 			//printf("<bdpdata> 4 NAME=%s", NAME);
 
 			if (strcmp(NAME, "-xyz") == 0){
-				fscanf(fi, "%lf", &bbdp->x0);
-				fscanf(fi, "%lf", &bbdp->y0);
-				fscanf(fi, "%lf", &bbdp->z0);
+				fscanf_s(fi, "%lf", &bbdp->x0);
+				fscanf_s(fi, "%lf", &bbdp->y0);
+				fscanf_s(fi, "%lf", &bbdp->z0);
 			}
 
 			else if (strcmp(NAME, "-WA") == 0)
-				fscanf(fi, "%lf", &bbdp->Wa);
+				fscanf_s(fi, "%lf", &bbdp->Wa);
 
 			else if (strcmp(NAME, "-WB") == 0)
-				fscanf(fi, "%lf", &bbdp->Wb);
+				fscanf_s(fi, "%lf", &bbdp->Wb);
 
 			else if (strcmp(NAME, "-WH") == 0){
-				fscanf(fi, "%lf", &bbdp->exw);
-				fscanf(fi, "%lf", &bbdp->exh);
+				fscanf_s(fi, "%lf", &bbdp->exw);
+				fscanf_s(fi, "%lf", &bbdp->exh);
 			}
 			// Satoh修正（2018/1/23）
 			else if (strcmp(NAME, "-exs") == 0)
 			{
-				fscanf(fi, "%s", NAME);
+				fscanf_s(fi, "%s", NAME, sizeof(NAME));
 				bbdp->exsfname = stralloc(NAME);
 				//外表面の検索
 				EXSF *Exs;
@@ -815,13 +818,14 @@ void bdpdata(FILE *fi, int *bdpn, BBDP **bp,EXSFS *Exsf){
 		rp = bbdp->RMP;
 		if (rp != NULL)
 			wp = rp->WD;
-		while (fscanf(fi, "%s", NAME), NAME[0] != '*'){
+		while (fscanf_s(fi, "%s", NAME, sizeof(NAME)), NAME[0] != '*'){
 
 			if (strcmp(NAME, "SBLK") == 0){
 				sb->ref = 0.0;
-				fscanf(fi, "%s", NAME);
+				fscanf_s(fi, "%s", NAME, sizeof(NAME));
 				sb->sbfname = stralloc(NAME);
 
+				// ex) SBLK HISASI 1Fhisa -xy 0 2.7 -DW 0.5 8.645 -a 90 ;
 				if (strcmp(sb->sbfname, "HISASI") == 0)
 					HISASHI(fi, sb);
 
@@ -831,6 +835,7 @@ void bdpdata(FILE *fi, int *bdpn, BBDP **bp,EXSFS *Exsf){
 				else if (strcmp(sb->sbfname, "SODEKABE") == 0)
 					SODEK(fi, sb);
 
+				// ex) SBLK MADOHIYOKE LDsudare-s1 -xy 0.7525 2.05 -DHW 0.1 2.0 1.8 -rgb 0.76 0.34 0.11 ;
 				else  if (strcmp(sb->sbfname, "MADOHIYOKE") == 0)
 					SCREEN(fi, sb);
 
@@ -920,7 +925,7 @@ void obsdata(FILE *fi, int *obsn, OBS **obs)
 
 	*obsn = 0;
 	obsp = *obs;
-	while (fscanf(fi, "%s", NAME), NAME[0] != '*'){
+	while (fscanf_s(fi, "%s", NAME, sizeof(NAME)), NAME[0] != '*'){
 		// OBS名称
 		obsp->fname = stralloc(NAME);
 
@@ -960,11 +965,11 @@ int		InputCount(FILE *fi, char *key)
 	N = 0;
 	ad = ftell(fi);
 
-	while (fscanf(fi, "%s", s) != EOF && *s != '*')
+	while (fscanf_s(fi, "%s", s, sizeof(s)) != EOF && *s != '*')
 	{
 		N++;
 
-		while (fscanf(fi, "%s", s) != EOF)
+		while (fscanf_s(fi, "%s", s, sizeof(s)) != EOF)
 		{
 			if (strcmp(s, key) == 0)
 				break;
@@ -984,7 +989,7 @@ int		SBLKCount(FILE *fi)
 	N = 0;
 	ad = ftell(fi);
 
-	while (fscanf(fi, "%s", s) != EOF && *s != '*')
+	while (fscanf_s(fi, "%s", s, sizeof(s)) != EOF && *s != '*')
 	{
 		if (strcmp(s, "SBLK") == 0)
 			N++;
@@ -1003,7 +1008,7 @@ int		RMPCount(FILE *fi)
 	N = 0;
 	ad = ftell(fi);
 
-	while (fscanf(fi, "%s", s) != EOF && *s != '*')
+	while (fscanf_s(fi, "%s", s, sizeof(s)) != EOF && *s != '*')
 	{
 		if (strcmp(s, "RMP") == 0)
 			N++;
@@ -1024,7 +1029,7 @@ int		WDCount(FILE *fi)
 
 	int Flg;
 	Flg = 0;
-	while (fscanf(fi, "%s", s) != EOF)
+	while (fscanf_s(fi, "%s", s, sizeof(s)) != EOF)
 	{
 		if (strcmp(s, "WD") == 0)
 			N++;

--- a/Source/func/ERRPRINT.c
+++ b/Source/func/ERRPRINT.c
@@ -21,10 +21,11 @@
 				     
  */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "common.h"
 #include "MODEL.h"
 
 /*------計算中の面から見える面と見えない面を判別する際に必要となる
@@ -35,15 +36,17 @@ void errbekt_printf(int n, int m, bekt *a, char *name)
   int i ;
   int j ;
   FILE *fp ;
+  char fname[SCHAR];
 
-  strcat(name,".gchi") ;
+  strcpy_s(fname, sizeof(fname), name);
+  strcat_s(fname, sizeof(fname), ".gchi") ;
 
-  if ((fp=fopen(name,"w"))==NULL){
+  if (fopen_s(&fp, fname,"w") != 0){
      printf("File not open errbekt_printf\n") ;
      exit(1) ;
   }
 
-  fprintf(fp,"%s ",name) ;
+  fprintf(fp,"%s ",fname) ;
 
   for(i=0 ;i<n ;i++){
     for(j=0 ;j<m ;j++)
@@ -88,10 +91,12 @@ void e_printf(int n, P_MENN *p, char *name)
 {
   int i ;
   FILE *fp ;
+  char fname[SCHAR];
 
-  strcat(name,".gchi") ;
+  strcpy_s(fname, sizeof(fname), name);
+  strcat_s(fname, sizeof(fname), ".gchi") ;
 
-  if ((fp=fopen(name,"w"))==NULL){
+  if (fopen_s(&fp, fname,"w") != 0){
     printf("File not open e_printf\n") ;
     exit(1) ;
   }
@@ -120,9 +125,12 @@ void mp_printf(int n, P_MENN *mp, char *name)
 {
   int i ;
   FILE *fp ;
+  char fname[SCHAR];
 
-  strcat(name,".gchi") ;
-  if ((fp=fopen(name,"w"))==NULL){
+  strcpy_s(fname, sizeof(fname), name);
+  strcat_s(fname, sizeof(fname), ".gchi") ;
+
+  if (fopen_s(&fp, fname,"w") != 0){
      printf("File not open mp_printf\n") ;
      exit(1) ;
   }
@@ -147,9 +155,12 @@ void gp_printf(XYZ **gp,P_MENN *mp, int mpn, int lpn, char *name)
   int i ;
   int k ;
   FILE *fp ;
+  char fname[SCHAR];
 
-  strcat(name,".gchi") ;
-  if ((fp=fopen(name,"w"))==NULL){
+  strcpy_s(fname, sizeof(fname), name);
+  strcat_s(fname, sizeof(fname), ".gchi") ;
+
+  if (fopen_s(&fp, fname,"w") != 0){
     printf("File not open gp_printf\n") ;
     exit(1) ;
   }
@@ -171,9 +182,12 @@ void lp_printf(int n, P_MENN *lp, char *name)
 
   int i ;
   FILE *fp ;
+  char fname[SCHAR];
 
-  strcat(name,".gchi") ;
-  if ((fp=fopen(name,"w"))==NULL){
+  strcpy_s(fname, sizeof(fname), name);
+  strcat_s(fname, sizeof(fname), ".gchi") ;
+
+  if (fopen_s(&fp, fname,"w") != 0){
     printf("File not open\n") ;
     exit(1) ;
   }
@@ -197,9 +211,12 @@ void lp_shad_printf(int lpn, P_MENN *lp, char *name)
   FILE *fp ;
   int i ;
   int j ;
+  char fname[SCHAR];
 
-  strcat(name,".gchi") ;
-  if ((fp=fopen(name,"w"))==NULL){
+  strcpy_s(fname, sizeof(fname), name);
+  strcat_s(fname, sizeof(fname), ".gchi") ;
+
+  if (fopen_s(&fp, fname,"w") != 0){
     printf("File not open lp_shad_printf\n") ;
     exit(1) ;
   }

--- a/Source/func/LPOP_placement.c
+++ b/Source/func/LPOP_placement.c
@@ -19,7 +19,7 @@
 						 FILE=LPOP_placement.c
 						 Create Date=2006.11.4
 						 */
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -39,26 +39,26 @@ void HOUSING_PLACE(int lpn, int mpn, P_MENN *lp, P_MENN *mp, char *RET)
 
 	mlpn = lpn + mpn;
 
-	strcpy(NAMAE1, RET);
-	strcat(NAMAE1, "_placeLP.gchi");
+	strcpy_s(NAMAE1, sizeof(NAMAE1), RET);
+	strcat_s(NAMAE1, sizeof(NAMAE1), "_placeLP.gchi");
 	//printf("%s\n",NAMAE1) ;
 
-	if ((fp1 = fopen(NAMAE1, "w")) == NULL){
+	if (fopen_s(&fp1, NAMAE1, "w") != 0){
 		printf("File not open _placeLP.gchi\n");
 		exit(1);
 	}
-	strcpy(NAMAE2, RET);
-	strcat(NAMAE2, "_placeOP.gchi");
+	strcpy_s(NAMAE2, sizeof(NAMAE2), RET);
+	strcat_s(NAMAE2, sizeof(NAMAE2), "_placeOP.gchi");
 
-	if ((fp2 = fopen(NAMAE2, "w")) == NULL){
+	if (fopen_s(&fp2, NAMAE2, "w") != 0){
 		printf("File not open _placeOP.gchi\n");
 		exit(1);
 	}
 
-	strcpy(NAMAE3, RET);
-	strcat(NAMAE3, "_placeALL.gchi");
+	strcpy_s(NAMAE3, sizeof(NAMAE3), RET);
+	strcat_s(NAMAE3, sizeof(NAMAE3), "_placeALL.gchi");
 
-	if ((fp3 = fopen(NAMAE3, "w")) == NULL){
+	if (fopen_s(&fp3, NAMAE3, "w") != 0){
 		printf("File not open _placeALL.gchi\n");
 		exit(1);
 	}

--- a/Source/func/MONTE_CARLO.c
+++ b/Source/func/MONTE_CARLO.c
@@ -47,7 +47,7 @@ void MONTE_CARLO(int mpn,int lpn,int NUM,P_MENN *MP,P_MENN *LP,
 #if test
   FILE *fp ;
 
-  if ((fp=fopen("monteOPLP.dat","w"))==NULL){
+  if (fopen_s(&fp, "monteOPLP.dat","w") != 0){
     printf("File not open\n") ;
     exit(1) ;
   }
@@ -286,7 +286,7 @@ double S=0.0, T=0.0 ;
 #if test
 FILE *fp1 ;
 
-if ((fp1=fopen("monte.dat","w"))==NULL){
+if (fopen_s(&fp1, "monte.dat","w") != 0){
    printf("File not open\n") ;
    exit(1) ;
  }

--- a/Source/func/STRCUT.c
+++ b/Source/func/STRCUT.c
@@ -13,7 +13,7 @@
 //You should have received a copy of the GNU General Public License
 //along with Foobar.If not, see < https://www.gnu.org/licenses/>.
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <ctype.h>
 #include <stdio.h>
 #include <string.h>
@@ -44,7 +44,7 @@ char *STRCUT(char *DATA, char a)
 	name=stralloc(res+1) ;
 	//printf ( "KKKK4\n" ) ;
 
-	strcpy(rev2,name) ;
+	strcpy_s(rev2, len + 1, name) ;
 	//printf ( "KKKK5\n" ) ;
 	ret=rev2 ;
 	len = (int)strlen(rev2);

--- a/Source/func/ZPRINT.c
+++ b/Source/func/ZPRINT.c
@@ -21,7 +21,7 @@
 
 */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <string.h>
 #include <stdlib.h>
 #include "fesy.h"
@@ -33,14 +33,18 @@
 #include "lib/u_psy.h"
 #include "MODEL.h"
 #include "func/ZPRINT.h"
+#include "common.h"
 
 void ZPRINT(P_MENN *lp, P_MENN *op, int lpn, int opn, char *name)
 {
 int i, k, j ;
 FILE *fp ;
+char fname[SCHAR];
 
-strcat(name,".gchi") ;
-if ((fp=fopen(name,"w"))==NULL){
+strcpy_s(fname, sizeof(fname), name);
+strcat_s(fname, sizeof(fname), ".gchi") ;
+
+if (fopen_s(&fp, fname,"w") != 0){
    printf("File not open\n") ;
    		preexit ( ) ;
 		exit(EXIT_ZPRI); 

--- a/Source/lib/u_ees3lb.c
+++ b/Source/lib/u_ees3lb.c
@@ -15,7 +15,7 @@
 
 /*  ees3lib.c  */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <ctype.h>
 #include <stdio.h>
 #include <string.h>
@@ -32,9 +32,9 @@
 /* Check heap status */
 void HeapCheck(char *s)
 {
+#if WINVER
 	int i ;
 
-#if WINVER
 	if (DEBUG)
 	{
 		//printf("HeatCheck  %s\n", s) ;
@@ -93,7 +93,7 @@ char *stralloc(char *s)
 		//c = ( char * ) _alloca (( strlen(s) + 1 ) * sizeof ( char )) ;
 
 		if ( c != NULL)
-			strcpy(c, s);
+			strcpy_s(c, N, s);
 		else
 		{
 			Eprint("xxxxx  stralloc  err=", s);
@@ -125,7 +125,7 @@ char *scalloc(unsigned int n, char *errkey)
 
 	if ( c == NULL)
 	{
-		sprintf(s, " -- f.scalloc   n=%d", n);
+		sprintf_s(s, sizeof(s), " -- f.scalloc   n=%d", n);
 		Eprint(errkey, s);
 
 		preexit ( ) ;
@@ -136,7 +136,7 @@ char *scalloc(unsigned int n, char *errkey)
 	for ( i = 0; i < ( int ) n; i++, st++ )
 		*st = ' ' ;
 
-	strcpy ( c, "" ) ;
+	strcpy_s (c, n, "" ) ;
 	return  c;
 }
 
@@ -169,7 +169,7 @@ char *charalloc(char c)
 	
 	if ((p = scalloc(1, "xxxxx  charalloc")) == NULL)
 	{
-		sprintf(s, "  errchar = [%c]", c);
+		sprintf_s(s, sizeof(s), "  errchar = [%c]", c);
 		Eprint("charalloc", s); 
 
 		preexit ( ) ;
@@ -192,7 +192,7 @@ int *icalloc(unsigned int n, char *errkey)
 	i = NULL ;
 	if (n > 0 && (i = (int *)malloc(n * sizeof(int))) == NULL)
 	{
-		sprintf(s, " -- f.icalloc   n=%d", n);
+		sprintf_s(s, sizeof(s), " -- f.icalloc   n=%d", n);
 		Eprint(errkey, s);
 
 		preexit ( ) ;
@@ -257,7 +257,7 @@ double *dcalloc(unsigned int n, char *errkey)
 	
 	if ( n > 0 && f == NULL)
 	{
-		sprintf(s, " -- f.dcalloc   n=%d", n);
+		sprintf_s(s, sizeof(s), " -- f.dcalloc   n=%d", n);
 		Eprint(errkey, s);
 
 		preexit ( ) ;
@@ -359,7 +359,7 @@ void Ercalloc(unsigned int n, char *errkey)
 {
     char  s[SCHAR];
 	
-    sprintf(s, " -- calloc   n=%d", n);
+    sprintf_s(s, sizeof(s), " -- calloc   n=%d", n);
     Eprint(errkey, s);
 }
 

--- a/Source/lib/u_inv.c
+++ b/Source/lib/u_inv.c
@@ -15,7 +15,7 @@
 
 /*  inv.c  */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -63,9 +63,9 @@ void	matinv(double *a, int n, int m, char *s)
 		if (big == 0.0)
 		{
 			if (s != NULL)
-				sprintf(E, "対角要素に０があります  matrix=%dx%d  i=%d  [%s]", m, m, i, s);
+				sprintf_s(E, sizeof(E), "対角要素に０があります  matrix=%dx%d  i=%d  [%s]", m, m, i, s);
 			else
-				sprintf(E, "対角要素に０があります  matrix=%dx%d  i=%d", m, m, i);
+				sprintf_s(E, sizeof(E), "対角要素に０があります  matrix=%dx%d  i=%d", m, m, i);
 
 			matprint("%.2g  ", m, mattemp);
 			free(mattemp);

--- a/Source/lib/u_mlib.c
+++ b/Source/lib/u_mlib.c
@@ -15,7 +15,7 @@
 
 /*  u_mlib.c  */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include "common.h"
 #include "lib/u_mlib.h"
@@ -36,7 +36,7 @@ double spcheat(char fluid)
       return ( ca ) ;
    else
    {
-      sprintf(s, "xxx fluid='%c'", fluid);
+      sprintf_s(s, sizeof(s), "xxx fluid='%c'", fluid);
       Eprint("<spcheat>", s); 
       return(-9999.0);
    }

--- a/Source/lib/valinit.c
+++ b/Source/lib/valinit.c
@@ -13,7 +13,7 @@
 //You should have received a copy of the GNU General Public License
 //along with Foobar.If not, see < https://www.gnu.org/licenses/>.
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include <string.h>
 #include "esize.h"
@@ -38,10 +38,10 @@ void	Simcinit ( SIMCONTL *S )
 	int		i ;
 	int		*dw, *dp ;
 
-	strcpy ( S->title, "" ) ;
+	strcpy_s ( S->title, sizeof(S->title), "" ) ;
 	S->File = S->wfname = S->ofname = S->unit = S->unitdy = NULL ;
 	S->fwdata = S->fwdata2 = S->ftsupw = NULL ;
-	strcpy ( S->timeid, "     " ) ;
+	strcpy_s ( S->timeid, sizeof(S->timeid), "     " ) ;
 	S->helmkey = S->wdtype = ' ' ;
 	S->daystartx = S->daystart = S->dayend = S->Dayntime = 0 ;
 	S->Ntimedyprt = S->Ntimehrprt = S->Nhelmsfpri = 0 ;
@@ -427,11 +427,11 @@ void	TMDTinit ( TMDT *t )
 	for ( i = 0; i < 5; i++ )
 		t->dat[i] = NULL ;
 
-	strcpy ( t->year, "" ) ;
-	strcpy ( t->mon, "" ) ;
-	strcpy ( t->day, "" ) ;
-	strcpy ( t->wkday, "" ) ;
-	strcpy ( t->time, "" ) ;
+	strcpy_s ( t->year, sizeof(t->year), "" ) ;
+	strcpy_s ( t->mon, sizeof(t->mon),"" ) ;
+	strcpy_s ( t->day, sizeof(t->day), "" ) ;
+	strcpy_s ( t->wkday, sizeof(t->wkday), "" ) ;
+	strcpy_s ( t->time, sizeof(t->time), "" ) ;
 
 	t->Year = t->Mon = t->Day = t->Time = 0 ;
 }

--- a/Source/lib/wdread.c
+++ b/Source/lib/wdread.c
@@ -16,7 +16,7 @@
 /*  wreadlib.c   */
 
 //#define		DEBUG	0
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
@@ -106,7 +106,7 @@ void Weatherdt(SIMCONTL *Simc, DAYTM *Daytm, LOCAT *Loc, WDAT *Wd, EXSF *Exs, ch
 			hspwdread (Simc->fwdata, Daytm->day, Loc, &Year, &Mon, &Day, &wkdy, dt);
 			if (Daytm->Mon != Mon || Daytm->Day != Day)
 			{
-				sprintf(s, "loop Mon/Day=%d/%d - data Mon/Day=%d/%d",
+				sprintf_s(s, sizeof(s), "loop Mon/Day=%d/%d - data Mon/Day=%d/%d",
 					Daytm->Mon, Daytm->Day, Mon, Day );
 				Eprint ( "<Weatherdt>", s ) ;
 
@@ -238,7 +238,7 @@ void  gtsupw (FILE *fp, char *Loc,
 	
 	if (ic == 0)
 	{ 
-		while ( fscanf ( fp, "%s", s ) != EOF )
+		while ( fscanf_s ( fp, "%s", s, sizeof(s) ) != EOF )
 		{ 
 			//fscanf(fp, " %s", s);
 			if (strcmp(s, "end") == 0)
@@ -249,7 +249,7 @@ void  gtsupw (FILE *fp, char *Loc,
 				//preexit() ;
 				//exit(1) ;
 				//以下４行、higuchi del supw.eflと気象データの地名に整合性の無い場合は、東京で走らせる。
-				sprintf ( E,"supw.eflに%sが登録されていません。", s) ;
+				sprintf_s ( E, sizeof(E), "supw.eflに%sが登録されていません。", s) ;
 				Eprint ( "<gtsupw>", E ) ;
 
 				preexit () ;
@@ -263,15 +263,15 @@ void  gtsupw (FILE *fp, char *Loc,
 		}
 		
 		for (m=0; m<12; m++)
-			fscanf(fp, "%lf", &Tsupw[m]);
+			fscanf_s(fp, "%lf", &Tsupw[m]);
 		
-		fscanf(fp, " %d %lf %lf ", nmx, Tgrav, DTgr);
+		fscanf_s(fp, " %d %lf %lf ", nmx, Tgrav, DTgr);
 		
 		ic = 1;
 
 		if (flg == 0)
 		{
-			sprintf(E, "supw.eflに%sが登録されていません。", s);
+			sprintf_s(E, sizeof(E), "supw.eflに%sが登録されていません。", s);
 			Eprint("<gtsupw>", E);
 			//getch();
 			preexit();
@@ -297,8 +297,8 @@ void hspwdread(FILE *fp, int nday,
 
 	if (ic == 0)
 	{
-		fscanf(fp,"%s %lf %lf %lf %lf %lf %lf ",
-			s, &Loc->Lat, &Loc->Lon, &Loc->Ls, &a,&b,&c);
+		fscanf_s(fp,"%s %lf %lf %lf %lf %lf %lf ",
+			s, sizeof(s), &Loc->Lat, &Loc->Lon, &Loc->Ls, &a,&b,&c);
 		Loc->name = stralloc ( s ) ;
 		
 		if ( ferr )

--- a/Source/mc/mcdesiccant.c
+++ b/Source/mc/mcdesiccant.c
@@ -16,7 +16,7 @@
 /*  mcdessicant.c  */
 /*  バッチ式デシカント空調機 */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
@@ -128,27 +128,27 @@ void Desiint(int NDesi, DESI *Desi,
 
 		if ( Desica->Uad < 0.0 )
 		{
-			sprintf ( Err, "Name=%s  Uad=%.4g", Desica->name, Desica->Uad ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s  Uad=%.4g", Desica->name, Desica->Uad ) ;
 			Eprint ( "Desiint", Err ) ;
 		}
 		if ( Desica->A < 0.0 )
 		{
-			sprintf ( Err, "Name=%s  A=%.4g", Desica->name, Desica->A ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s  A=%.4g", Desica->name, Desica->A ) ;
 			Eprint ( "Desiint", Err ) ;
 		}
 		if ( Desica->r < 0.0 )
 		{
-			sprintf ( Err, "Name=%s  r=%.4g", Desica->name, Desica->r ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s  r=%.4g", Desica->name, Desica->r ) ;
 			Eprint ( "Desiint", Err ) ;
 		}
 		if ( Desica->rows < 0.0 )
 		{
-			sprintf ( Err, "Name=%s  rows=%.4g", Desica->name, Desica->rows ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s  rows=%.4g", Desica->name, Desica->rows ) ;
 			Eprint ( "Desiint", Err ) ;
 		}
 		if ( Desica->ms < 0.0 )
 		{
-			sprintf ( Err, "Name=%s  ms=%.4g", Desica->name, Desica->ms ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s  ms=%.4g", Desica->name, Desica->ms ) ;
 			Eprint ( "Desiint", Err ) ;
 		}
 

--- a/Source/mc/mceqcadat.c
+++ b/Source/mc/mceqcadat.c
@@ -15,7 +15,7 @@
 
 /*  eqcadat.c  */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -185,7 +185,7 @@ void Eqcadata (FILE *f, char *dsn, EQCAT *Eqcat)
 			Ercalloc(N, dsn);
 	}
 
-    if((frf = fopen("reflist.efl", "r")) == NULL)
+    if(fopen_s(&frf, "reflist.efl", "r") != 0)
 		Eprint(" file ", "reflist.efl");
 
 	N = RFCMPLSTMX ;
@@ -214,7 +214,7 @@ void Eqcadata (FILE *f, char *dsn, EQCAT *Eqcat)
     Refcmpdat(frf, &Eqcat->Nrfcmp, Eqcat->Rfcmp);
     fclose (frf);
 
-	if (( frf = fopen("pumpfanlst.efl", "r")) == NULL)
+	if (fopen_s(&frf, "pumpfanlst.efl", "r") != 0)
 		Eprint(" file ", "pumpfanlst.efl") ;
 	N = pflistcount (frf) ;
 	if (N > 0 && (Eqcat->pfcmp = (PFCMP *)calloc(N, sizeof(PFCMP))) == NULL)
@@ -245,11 +245,11 @@ void Eqcadata (FILE *f, char *dsn, EQCAT *Eqcat)
 	// Satoh追加 2013/10/26
 	Evacca = Eqcat->Evacca ;
 
-    sprintf (E, ERRFMT, dsn);
+    sprintf_s (E, sizeof(E), ERRFMT, dsn);
     
 	//printf("3 %s\n", Room->trnx->nextroom->name) ;
 
-    while (fscanf(f, "%s", s), s[0] != '*')
+    while (fscanf_s(f, "%s", s, sizeof(s)), s[0] != '*')
     {
 		//printf("%s %s\n", s, Room->trnx->nextroom->name) ;
 
@@ -257,7 +257,7 @@ void Eqcadata (FILE *f, char *dsn, EQCAT *Eqcat)
 		{ 
 			Hccca->name = NULL ;
 
-			while (fscanf(f, "%s", s), s[0] != ';')
+			while (fscanf_s(f, "%s", s, sizeof(s)), s[0] != ';')
 			{
 				if ((ce=strchr(s,';')) != 0)
 					*ce=  '\0';	     
@@ -271,7 +271,7 @@ void Eqcadata (FILE *f, char *dsn, EQCAT *Eqcat)
 		{ 
 			Boica->name = NULL ;
 
-			while (fscanf(f, "%s", s), s[0] != ';')
+			while (fscanf_s(f, "%s", s, sizeof(s)), s[0] != ';')
 			{
 				if ((ce=strchr(s,';')) != 0)
 					*ce=  '\0';
@@ -286,7 +286,7 @@ void Eqcadata (FILE *f, char *dsn, EQCAT *Eqcat)
 			Collca->name = NULL ;
 			Collca->Fd = 0.9 ;
 
-			while (fscanf(f, "%s", ss), ss[0] != ';')
+			while (fscanf_s(f, "%s", ss, sizeof(ss)), ss[0] != ';')
 			{
 				if ((ce=strchr(ss,';')) != 0)
 					*ce=  '\0';
@@ -300,7 +300,7 @@ void Eqcadata (FILE *f, char *dsn, EQCAT *Eqcat)
 		{ 
 			PVca->name = NULL ;
 
-			while (fscanf(f, "%s", ss), ss[0] != ';')
+			while (fscanf_s(f, "%s", ss, sizeof(ss)), ss[0] != ';')
 			{
 				if ((ce=strchr(ss,';')) != 0)
 					*ce=  '\0';
@@ -314,7 +314,7 @@ void Eqcadata (FILE *f, char *dsn, EQCAT *Eqcat)
 		{ 
 			Refaca->name = NULL ;
 
-			while (fscanf(f, "%s", s), s[0] != ';')
+			while (fscanf_s(f, "%s", s, sizeof(s)), s[0] != ';')
 			{
 				if ((ce=strchr(s,';')) != 0)
 					*ce=  '\0';
@@ -329,7 +329,7 @@ void Eqcadata (FILE *f, char *dsn, EQCAT *Eqcat)
 		{ 
 			Pipeca->name = NULL ;
 			
-			while (fscanf(f, "%s", ss), ss[0] != ';')
+			while (fscanf_s(f, "%s", ss, sizeof(ss)), ss[0] != ';')
 			{
 				if ((ce=strchr(ss,';')) != 0)
 					*ce=  '\0';
@@ -343,7 +343,7 @@ void Eqcadata (FILE *f, char *dsn, EQCAT *Eqcat)
 		{ 
 			Stankca->name = NULL ;
 
-			while (fscanf(f, "%s", s), s[0] != ';')
+			while (fscanf_s(f, "%s", s, sizeof(s)), s[0] != ';')
 			{
 				if ((ce=strchr(s,';')) != 0)
 					*ce=  '\0';
@@ -357,7 +357,7 @@ void Eqcadata (FILE *f, char *dsn, EQCAT *Eqcat)
 		{ 
 			Hexca->name = NULL ;
 
-			while (fscanf(f, "%s", s), s[0] != ';')
+			while (fscanf_s(f, "%s", s, sizeof(s)), s[0] != ';')
 			{
 				if ((ce=strchr(s,';')) != 0)
 					*ce=  '\0';
@@ -374,7 +374,7 @@ void Eqcadata (FILE *f, char *dsn, EQCAT *Eqcat)
 			Pumpca->val = NULL ;
 			Pumpca->pfcmp = NULL ;
 
-			while (fscanf(f, "%s", ss), ss[0] != ';')
+			while (fscanf_s(f, "%s", ss, sizeof(ss)), ss[0] != ';')
 			{
 				if ((ce=strchr(ss,';')) != 0)
 					*ce=  '\0';
@@ -390,7 +390,7 @@ void Eqcadata (FILE *f, char *dsn, EQCAT *Eqcat)
 			vavca->dTset = -999.0 ;
 			vavca->name = NULL ;
 
-			while (fscanf(f, "%s", ss), ss[0] != ';')
+			while (fscanf_s(f, "%s", ss, sizeof(ss)), ss[0] != ';')
 			{
 				if ((ce=strchr(ss,';')) != 0)
 					*ce=  '\0';
@@ -412,7 +412,7 @@ void Eqcadata (FILE *f, char *dsn, EQCAT *Eqcat)
 			OMvavca->Gmin = -999.0 ;
 
 			//printf("5 %s\n", Room->trnx->nextroom->name) ;
-			while (fscanf(f, "%s", ss), ss[0] != ';')
+			while (fscanf_s(f, "%s", ss, sizeof(ss)), ss[0] != ';')
 			{
 				//printf("%s %s\n", ss, Room->trnx->nextroom->name) ;
 				if ((ce=strchr(ss,';')) != 0)
@@ -431,7 +431,7 @@ void Eqcadata (FILE *f, char *dsn, EQCAT *Eqcat)
 			stheatca->name = NULL ;
 			stheatca->pcmname = NULL;
 
-			while (fscanf(f, "%s", s), s[0] != ';')
+			while (fscanf_s(f, "%s", s, sizeof(s)), s[0] != ';')
 			{
 				if ((ce = strchr(s, ';')) != 0)
 					*ce = '\0' ;
@@ -450,7 +450,7 @@ void Eqcadata (FILE *f, char *dsn, EQCAT *Eqcat)
 			Thexca->et = -999.0 ;
 			Thexca->eh = -999.0 ;
 
-			while ( fscanf ( f, "%s", s), *s != ';')
+			while ( fscanf_s ( f, "%s", s, sizeof(s)), *s != ';')
 			{
 				if (( ce = strchr(s, ';')) != 0)
 					*ce = '\0' ;
@@ -468,7 +468,7 @@ void Eqcadata (FILE *f, char *dsn, EQCAT *Eqcat)
 		{
 			Desica->name = NULL ;
 
-			while (fscanf(f, "%s", s), s[0] != ';')
+			while (fscanf_s(f, "%s", s, sizeof(s)), s[0] != ';')
 			{
 				if ((ce = strchr(s, ';')) != 0)
 					*ce = '\0' ;
@@ -485,7 +485,7 @@ void Eqcadata (FILE *f, char *dsn, EQCAT *Eqcat)
 		{
 			Evacca->name = NULL ;
 
-			while (fscanf(f, "%s", s), s[0] != ';')
+			while (fscanf_s(f, "%s", s, sizeof(s)), s[0] != ';')
 			{
 				if ((ce = strchr(s, ';')) != 0)
 					*ce = '\0' ;
@@ -531,7 +531,7 @@ void	Eqpcount ( FILE *fi, int *NBOI, int *NREFA, int *NCOL, int *NSTANK, int *NH
 
 	ad = ftell ( fi ) ;		// 読み込み位置を覚えておく
 
-	while ( fscanf ( fi, "%s", s ) !=EOF && *s != '*' )
+	while ( fscanf_s ( fi, "%s", s, sizeof(s) ) !=EOF && *s != '*' )
 	{
 		if (strcmp(s, HCCOIL_TYPE) == 0)	// 機器仕様のキーワードが見つかったら個数をインクリメント
 			(*NHCC)++;
@@ -565,7 +565,7 @@ void	Eqpcount ( FILE *fi, int *NBOI, int *NREFA, int *NCOL, int *NSTANK, int *NH
 		else if (strcmp(s, EVAC_TYPE) == 0)
 			(*NEVAC)++ ;
 
-		fscanf ( fi, "%*[^;] %*c" ) ;
+		fscanf_s ( fi, "%*[^;] %*c" ) ;
 	}
 
 	fseek ( fi, ad, SEEK_SET ) ;	// 読み込み位置を元に戻す
@@ -576,11 +576,11 @@ int	pflistcount ( FILE *fl )
 	int		N = 0 ;
 	char	s[SCHAR], c ;
 	
-	while ( fscanf ( fl, "%s", s ) != EOF, *s != '*' )
+	while ( fscanf_s ( fl, "%s", s, sizeof(s) ) != EOF, *s != '*' )
 	{
 		if ( strcmp(s,"!") == 0)
 		{
-			while ( fscanf ( fl,"%c", &c), c != '\n' )
+			while ( fscanf_s ( fl,"%c", &c, 1), c != '\n' )
 				;
 		}
 		else if (strcmp(s, ";") == 0)

--- a/Source/mc/mcevcooling.c
+++ b/Source/mc/mcevcooling.c
@@ -15,7 +15,7 @@
 
 /* mcevcooling.c */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
@@ -83,13 +83,13 @@ void	Evacint(int Nevac, EVAC *Evac)
 		cat = Evac->cat;
 		if (cat->N < 0)
 		{
-			sprintf(s, "Name=%s catname=%s 分割数が未定義です",
+			sprintf_s(s, sizeof(s), "Name=%s catname=%s 分割数が未定義です",
 				Evac->name, cat->name);
 			Eprint("<Evacint>", s);
 		}
 		if (cat->Adry < 0. || cat->Awet < 0. || (cat->Nlayer < 0 && (cat->hdry < 0. || cat->hwet < 0.)))
 		{
-			sprintf(s, "Name=%s catname=%s Adry=%.1g Awet=%.1g hdry=%.1g hwet=%.1g\n",
+			sprintf_s(s, sizeof(s), "Name=%s catname=%s Adry=%.1g Awet=%.1g hdry=%.1g hwet=%.1g\n",
 				Evac->name, cat->name, cat->Adry, cat->Awet, cat->hdry, cat->hwet);
 			Eprint("<Evacint>", s);
 		}

--- a/Source/mc/mchcload.c
+++ b/Source/mc/mchcload.c
@@ -17,7 +17,7 @@
 
 /*  空調負荷仮想機器  */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
@@ -82,12 +82,12 @@ void rmacdat(HCLOAD *Hcld)
 	int  n = 0;
 	char     Err[SCHAR];
 	
-	sprintf(Err, ERRFMT, "(rmacdat)");
-	
+	sprintf_s(Err, sizeof(Err), ERRFMT, "(rmacdat)");
+
 	ss = Hcld->cmp->tparm;
 	Hcld->Qhmax = Hcld->Qh = Hcld->COPc = Hcld->COPh = -999.0 ;
 	Hcld->Qcmax = Hcld->Qc = 999. ;
-	while(sscanf(ss, "%s", s), strchr(s,'*') == NULL)
+	while(sscanf_s(ss, "%s", s, sizeof(s)), strchr(s,'*') == NULL)
 	{
 		ss += strlen(s);
 		while(isspace(*ss))
@@ -158,7 +158,7 @@ void rmacddat(HCLOAD *Hcld)
 	extern double ca, cv ;
 	int		i, j ;
 	
-	sprintf(Err, ERRFMT, "(rmacddat)");
+	sprintf_s(Err, sizeof(Err), ERRFMT, "(rmacddat)");
 	
 	ss = Hcld->cmp->tparm;
 	//Hcld->Qhmax = Hcld->Qh = Hcld->COPc = Hcld->COPh = -999.0 ;
@@ -166,7 +166,7 @@ void rmacddat(HCLOAD *Hcld)
 	Hcld->Ecmax = Hcld->Ec = Hcld->Ecmin = Hcld->Qh = Hcld->Qhmax = Hcld->Qhmin 
 		= Hcld->Ehmax = Hcld->Eh = Hcld->Ehmin = -999. ;
 	Hcld->Gi = Hcld->Go = -999.0 ;
-	while(sscanf(ss, "%s", s), strchr(s,'*') == NULL)
+	while(sscanf_s(ss, "%s", s, sizeof(s)), strchr(s,'*') == NULL)
 	{
 		ss += strlen(s);
 		while(isspace(*ss))

--- a/Source/mc/mchexchgr.c
+++ b/Source/mc/mchexchgr.c
@@ -15,7 +15,7 @@
 
 /* hexchgr.c */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <string.h>
 #include <stdlib.h>
 
@@ -94,7 +94,7 @@ void Hexcfv(int Nhex, HEX *Hex)
 
 			if ( Hex->eff < 0.0 )
 			{
-				sprintf ( Err, "Name=%s  eff=%.4g", Hex->cmp->name, Hex->eff ) ;
+				sprintf_s ( Err, sizeof(Err), "Name=%s  eff=%.4g", Hex->cmp->name, Hex->eff ) ;
 				Eprint ( "Hexcfv", Err ) ;
 			}
 

--- a/Source/mc/mcmecsys.c
+++ b/Source/mc/mcmecsys.c
@@ -15,7 +15,7 @@
 
 /*  mecsys.c  */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include "fesy.h"
 #include "fnmcs.h"
 #include "fnfio.h"
@@ -35,7 +35,7 @@ void	Mecsinit(double dTM, EQSYS *Eqsys,
 	Collint ( Eqsys->Ncoll, Eqsys->Coll, Nexsf, Exsf, Wd ) ;
 	Pipeint ( Eqsys->Npipe, Eqsys->Pipe, Simc, Ncompnt, Compnt, Wd ) ;
 	/////////////////////////////////
-	sprintf(hptest, "Mecsinit") ;
+	sprintf_s(hptest, sizeof(hptest), "Mecsinit") ;
 	HeapCheck(hptest) ;
 	/////////////////////////////////
 	Stankint ( dTM, Eqsys->Nstank, Eqsys->Stank, Simc, Ncompnt, Compnt, Wd ) ;

--- a/Source/mc/mcomvav.c
+++ b/Source/mc/mcomvav.c
@@ -17,7 +17,7 @@
 
 /*  OM用変風量コントローラ */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -279,7 +279,7 @@ int colkey(char *s, char **key)
 		return 0;
 	else
 	{  
-		strcpy(ss, s); 
+		strcpy_s(ss, sizeof(ss), s); 
 		
 		key[0] = ss;
 		nk = 1;

--- a/Source/mc/mcpipe.c
+++ b/Source/mc/mcpipe.c
@@ -15,7 +15,7 @@
 
 /*  pipe.c  */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
@@ -94,12 +94,12 @@ void Pipeint(int Npipe, PIPE *Pipe,
 
 		if ( Pipe->cat->Ko < 0.0 )
 		{
-			sprintf ( Err, "Name=%s  Ko=%.4g", Pipe->cmp->name, Pipe->cat->Ko ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s  Ko=%.4g", Pipe->cmp->name, Pipe->cat->Ko ) ;
 			Eprint ( "Pipeint", Err ) ;
 		}
 		if ( Pipe->L < 0.0 )
 		{
-			sprintf ( Err, "Name=%s  L=%.4g", Pipe->cmp->name, Pipe->L ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s  L=%.4g", Pipe->cmp->name, Pipe->L ) ;
 			Eprint ( "Pipeint", Err ) ;
 		}
 	}
@@ -126,7 +126,7 @@ void Pipecfv(int Npipe, PIPE *Pipe)
 				Te = Pipe->room->Tot ;
 			else
 			{
-				sprintf ( s, "Undefined Pipe Environment  name=%s", Pipe->name ) ;
+				sprintf_s ( s, sizeof(s), "Undefined Pipe Environment  name=%s", Pipe->name ) ;
 				Eprint ( "<Pipecfv>", s ) ;
 			}
             

--- a/Source/mc/mcpump.c
+++ b/Source/mc/mcpump.c
@@ -17,7 +17,7 @@
 
 /*  ポンプ   */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
@@ -239,7 +239,7 @@ double	PumpFanPLC ( double XQ, PUMP *Pump )
 
 	if (cat->pfcmp == NULL)
 	{
-		sprintf ( Err, "<PumpFanPLC>  PFtype=%c  type=%s", cat->pftype, cat->type ) ;
+		sprintf_s ( Err, sizeof(Err), "<PumpFanPLC>  PFtype=%c  type=%s", cat->pftype, cat->type ) ;
 		Eprint ( "PUMP oir FAN", Err ) ;
 		Buff = 0.0 ;
 	}
@@ -501,11 +501,11 @@ void	PFcmpdata(FILE *fl, int *Npfcmp, PFCMP *pfcmp)
 	PFCMP	*Cmp ;
 
 	Cmp = pfcmp ;
-	while ( fscanf(fl, "%s", s) != EOF, s[0] != '*' )
+	while ( fscanf_s(fl, "%s", s, sizeof(s)) != EOF, s[0] != '*' )
 	{
 		if (strcmp(s, "!") == 0)
 		{
-			while ( fscanf ( fl,"%c", &c), c != '\n' )
+			while ( fscanf_s ( fl,"%c", &c, 1), c != '\n' )
 				;
 		}
 		else
@@ -517,11 +517,11 @@ void	PFcmpdata(FILE *fl, int *Npfcmp, PFCMP *pfcmp)
 			else
 				Eprint("<pumpfanlst.efl>", s) ;
 			
-			fscanf(fl, "%s", s) ;
+			fscanf_s(fl, "%s", s, sizeof(s)) ;
 			pfcmp->type = stralloc(s) ;
 			
 			i = 0 ;
-			while (fscanf(fl, "%s", s) != EOF, s[0] != ';' )
+			while (fscanf_s(fl, "%s", s, sizeof(s)) != EOF, s[0] != ';' )
 			{
 				pfcmp->dblcoeff[i] = atof(s) ;
 				i++ ;

--- a/Source/mc/mcpv.c
+++ b/Source/mc/mcpv.c
@@ -15,7 +15,7 @@
 
 /*  solrcol.c  */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
@@ -123,49 +123,49 @@ void PVint(int Npv, PV *PV, int Nexsf, EXSF *Exs, WDAT *Wd)
 
 		if ( PV->cat->KHD < 0.0 )
 		{
-			sprintf ( Err, "Name=%s KHD=%.4g", PV->cmp->name, PV->cat->KHD ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s KHD=%.4g", PV->cmp->name, PV->cat->KHD ) ;
 			Eprint("PVint", Err ) ;
 		}
 
 		if ( PV->cat->KPD < 0.0 )
 		{
-			sprintf ( Err, "Name=%s KHD=%.4g", PV->cmp->name, PV->cat->KPD ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s KHD=%.4g", PV->cmp->name, PV->cat->KPD ) ;
 			Eprint("PVint", Err ) ;
 		}
 
 		if ( PV->cat->KPM < 0.0 )
 		{
-			sprintf ( Err, "Name=%s KPM=%.4g", PV->cmp->name, PV->cat->KPM ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s KPM=%.4g", PV->cmp->name, PV->cat->KPM ) ;
 			Eprint("PVint", Err ) ;
 		}
 
 		if ( PV->cat->KPA < 0.0 )
 		{
-			sprintf ( Err, "Name=%s KPA=%.4g", PV->cmp->name, PV->cat->KPA ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s KPA=%.4g", PV->cmp->name, PV->cat->KPA ) ;
 			Eprint("PVint", Err ) ;
 		}
 
 		if ( PV->cat->effINO < 0.0 )
 		{
-			sprintf ( Err, "Name=%s EffInv=%.4g", PV->cmp->name, PV->cat->effINO ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s EffInv=%.4g", PV->cmp->name, PV->cat->effINO ) ;
 			Eprint("PVint", Err ) ;
 		}
 
 		if ( PV->cat->apmax > 0.0 )
 		{
-			sprintf ( Err, "Name=%s apmax=%.4g", PV->cmp->name, PV->cat->apmax ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s apmax=%.4g", PV->cmp->name, PV->cat->apmax ) ;
 			Eprint("PVint", Err ) ;
 		}
 
 		if ( PV->PVcap < 0.0 )
 		{
-			sprintf ( Err, "Name=%s PVcap=%.4g", PV->cmp->name, PV->PVcap ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s PVcap=%.4g", PV->cmp->name, PV->PVcap ) ;
 			Eprint("PVint", Err ) ;
 		}
 
 		if ( PV->Area < 0.0 )
 		{
-			sprintf ( Err, "Name=%s Area=%.4g", PV->cmp->name, PV->Area ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s Area=%.4g", PV->cmp->name, PV->Area ) ;
 			Eprint("PVint", Err ) ;
 		}
 

--- a/Source/mc/mcrefas.c
+++ b/Source/mc/mcrefas.c
@@ -15,7 +15,7 @@
 
 /*  refas.c */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <string.h>
 #include <stdlib.h>
 #include "fesy.h"
@@ -153,7 +153,7 @@ void Refaint(int Nrefa, REFA *Refa, WDAT *Wd, int Ncompnt, COMPNT *Compnt)
 		}
 		
 		/*****************************
-		sprintf ( Err, "Name=%s  Ph=%.4g", Refa->cmp->name, Refa->cat->Ph ) ;
+		sprintf_s ( Err, sizeof(Err), "Name=%s  Ph=%.4g", Refa->cmp->name, Refa->cat->Ph ) ;
 		if ( Refa->cat->Ph < 0.0 )
 			Eprint ( "Refaint", Err ) ;
 			************************************/
@@ -263,7 +263,7 @@ void Refacfv(int Nrefa, REFA *Refa)
 					}
 					else
 					{
-						sprintf( s, "xxxxx refacoeff xxx stop xx  %s chmode=%c  monitor=%s",
+						sprintf_s( s, sizeof(s), "xxxxx refacoeff xxx stop xx  %s chmode=%c  monitor=%s",
 							Refa->name, Refa->chmode, Refa->cmp->elouts->emonitr->cmp->name);
 						Eprint ( "<Refacfv>", s ) ;
 

--- a/Source/mc/mcreflib.c
+++ b/Source/mc/mcreflib.c
@@ -15,7 +15,7 @@
 
 /*   mc_reflib.c                     */                           
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include "esize.h"
 #include "fesy.h"
@@ -35,22 +35,22 @@ void Refcmpdat(FILE *frf, int *Nrfcmp, RFCMP *Rfcmp)
 	
 	rfc = Rfcmp;
 	
-	while (fscanf(frf, "%s", s), s[0] != '*')
+	while (fscanf_s(frf, "%s", s, sizeof(s)), s[0] != '*')
 	{
         Rfcmp->name = stralloc(s);
 		
-		fscanf(frf, "%s", s);
+		fscanf_s(frf, "%s", s, sizeof(s));
 		Rfcmp->cname = stralloc(s);
 		
 		for (i=0; i<4; i++)
-			fscanf(frf, "%lf", &Rfcmp->e[i]);
+			fscanf_s(frf, "%lf", &Rfcmp->e[i]);
 		for (i=0; i<4; i++)
-			fscanf(frf, "%lf", &Rfcmp->d[i]);
+			fscanf_s(frf, "%lf", &Rfcmp->d[i]);
 		for (i=0; i<4; i++)
-			fscanf(frf, "%lf", &Rfcmp->w[i]);
-		fscanf(frf, "%lf %lf %lf %lf", &Rfcmp->Teo[0], &Rfcmp->Teo[1], 	
+			fscanf_s(frf, "%lf", &Rfcmp->w[i]);
+		fscanf_s(frf, "%lf %lf %lf %lf", &Rfcmp->Teo[0], &Rfcmp->Teo[1], 	
 			&Rfcmp->Tco[0], &Rfcmp->Tco[1]);
-		fscanf(frf, "%lf", &Rfcmp->Meff);
+		fscanf_s(frf, "%lf", &Rfcmp->Meff);
 		
 		Rfcmp++;	
 	}

--- a/Source/mc/mcsolrcol.c
+++ b/Source/mc/mcsolrcol.c
@@ -15,7 +15,7 @@
 
 /*  solrcol.c  */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
@@ -92,22 +92,22 @@ void Collint(int Ncoll, COLL *Coll, int Nexsf, EXSF *Exs, WDAT *Wd)
 
 		if ( Coll->cat->b0 < 0.0 )
 		{
-			sprintf ( Err, "Name=%s b0=%.4g", Coll->cmp->name, Coll->cat->b0 ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s b0=%.4g", Coll->cmp->name, Coll->cat->b0 ) ;
 			Eprint("Collint", Err ) ;
 		}
 		if ( Coll->cat->b1 < 0.0 )
 		{
-			sprintf ( Err, "Name=%s b1=%.4g", Coll->cmp->name, Coll->cat->b1 ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s b1=%.4g", Coll->cmp->name, Coll->cat->b1 ) ;
 			Eprint("Collint", Err ) ;
 		}
 		if ( Coll->cat->Ac < 0.0 )
 		{
-			sprintf ( Err, "Name=%s Ac=%.4g", Coll->cmp->name, Coll->cat->Ac ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s Ac=%.4g", Coll->cmp->name, Coll->cat->Ac ) ;
 			Eprint("Collint", Err ) ;
 		}
 		if ( Coll->cat->Ag < 0.0 )
 		{
-			sprintf ( Err, "Name=%s Ag=%.4g", Coll->cmp->name, Coll->cat->Ag ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s Ag=%.4g", Coll->cmp->name, Coll->cat->Ag ) ;
 			Eprint("Collint", Err ) ;
 		}
 

--- a/Source/mc/mcstank.c
+++ b/Source/mc/mcstank.c
@@ -17,7 +17,7 @@
 
 /*  95/11/17 rev  */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
@@ -61,10 +61,10 @@ int Stankdata(FILE *f, char *s, STANKCA *Stankca)
 	}
 	else if (strcmp(s, "-S") == 0)
 	{
-		strcat(s, "  ");
+		strcat_s(s, sizeof(s), "  ");
 		st = s + strlen(s);	   
-		fscanf(f, "%[^*]*", st); 
-		strcat(s, " *"); 	   
+		fscanf_s(f, "%[^*]*", st, sizeof(s) - strlen(s)); 
+		strcat_s(s, sizeof(s), " *");
 		Stankca->tparm = stralloc(s);
 	}   
 	else
@@ -95,7 +95,7 @@ void Stankmemloc(char *errkey, STANK *Stank)
 	
 	/******* printf("xxxx Stankmemloc  tparm=%s\n", st); *****/
 	
-	while (sscanf(st, "%s", ss), *ss != '*')
+	while (sscanf_s(st, "%s", ss, sizeof(ss)), *ss != '*')
 	{
 		parm[np] = st;
 		np++ ;
@@ -117,7 +117,7 @@ void Stankmemloc(char *errkey, STANK *Stank)
 	// np：タンクへの流入数
 	for (j = 0; j < np; j++)
 	{
-		sscanf(parm[j], "%s", ss);
+		sscanf_s(parm[j], "%s", ss, sizeof(ss));
 		
 		if (strncmp(ss, "N=", 2) == 0)
 			Stank->Ndiv = atoi(ss + 2);
@@ -214,7 +214,7 @@ void Stankint(double dTM, int Nstank, STANK *Stank,
 	char	*s, ss[SCHAR], mrk, Err[SCHAR], E[SCHAR] ;
 	double	Tso;
 	
-	strcpy ( E, "Stankint" ) ;
+	strcpy_s ( E, sizeof(E), "Stankint" ) ;
 
 	for (i = 0; i < Nstank; i++, Stank++)
 	{ 
@@ -233,7 +233,7 @@ void Stankint(double dTM, int Nstank, STANK *Stank,
 				s++;
 				for (j = 0; j < Stank->Ndiv; j++)
 				{
-					sscanf(s, " %s ", ss);
+					sscanf_s(s, " %s ", ss, sizeof(ss));
 					
 					if (*ss == TANK_EMPTY)
 					{
@@ -286,22 +286,22 @@ void Stankint(double dTM, int Nstank, STANK *Stank,
 
 		if ( Stank->cat->Vol < 0.0 )
 		{
-			sprintf ( Err, "Name=%s  Vol=%.4g", Stank->cmp->name, Stank->cat->Vol ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s  Vol=%.4g", Stank->cmp->name, Stank->cat->Vol ) ;
 			Eprint ( E, Err ) ;
 		}
 		if ( Stank->cat->KAside < 0.0 )
 		{
-			sprintf ( Err, "Name=%s  KAside=%.4g", Stank->cmp->name, Stank->cat->KAside ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s  KAside=%.4g", Stank->cmp->name, Stank->cat->KAside ) ;
 			Eprint ( E, Err ) ;
 		}
 		if ( Stank->cat->KAtop < 0.0 )
 		{
-			sprintf ( Err, "Name=%s  KAtop=%.4g", Stank->cmp->name, Stank->cat->KAtop ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s  KAtop=%.4g", Stank->cmp->name, Stank->cat->KAtop ) ;
 			Eprint ( E, Err ) ;
 		}
 		if ( Stank->cat->KAbtm < 0.0 )
 		{
-			sprintf ( Err, "Name=%s  KAbtm=%.4g", Stank->cmp->name, Stank->cat->KAbtm ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s  KAbtm=%.4g", Stank->cmp->name, Stank->cat->KAbtm ) ;
 			Eprint ( E, Err ) ;
 		}
 	}

--- a/Source/mc/mcstheat.c
+++ b/Source/mc/mcstheat.c
@@ -16,7 +16,7 @@
 /*  mcstheat.c  */
 /*  電気蓄熱式暖房器 */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
@@ -107,7 +107,7 @@ void Stheatint(int Nstheat, STHEAT *stheat,
 			}
 			if (stheat->pcm == NULL)
 			{
-				sprintf(Err, "STHEAT %s のPCM=%sが見つかりません", stheat->name, stheat->cat->pcmname);
+				sprintf_s(Err, sizeof(Err), "STHEAT %s のPCM=%sが見つかりません", stheat->name, stheat->cat->pcmname);
 				Eprint(Err, "<Stheatint>");
 				preexit();
 			}
@@ -117,22 +117,22 @@ void Stheatint(int Nstheat, STHEAT *stheat,
 
 		if ( st->Q < 0.0 )
 		{
-			sprintf ( Err, "Name=%s  Q=%.4g", stheat->name, st->Q ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s  Q=%.4g", stheat->name, st->Q ) ;
 			Eprint ( "Stheatinit", Err ) ;
 		}
 		if ( stheat->pcm == NULL && st->Hcap < 0.0 )
 		{
-			sprintf ( Err, "Name=%s  Hcap=%.4g", stheat->name, st->Hcap ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s  Hcap=%.4g", stheat->name, st->Hcap ) ;
 			Eprint ( "Stheatinit", Err ) ;
 		}
 		if ( st->KA < 0.0 )
 		{
-			sprintf ( Err, "Name=%s  KA=%.4g", stheat->name, st->KA ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s  KA=%.4g", stheat->name, st->KA ) ;
 			Eprint ( "Stheatinit", Err ) ;
 		}
 		if ( st->eff < 0.0 )
 		{
-			sprintf ( Err, "Name=%s  eff=%.4g", stheat->name, st->eff ) ;
+			sprintf_s ( Err, sizeof(Err), "Name=%s  eff=%.4g", stheat->name, st->eff ) ;
 			Eprint ( "Stheatinit", Err ) ;
 		}
 

--- a/Source/mc/mcthex.c
+++ b/Source/mc/mcthex.c
@@ -15,7 +15,7 @@
 
 /* mcthex.c */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <string.h>
 #include <stdlib.h>
 
@@ -77,7 +77,7 @@ void	Thexint ( int Nthex, THEX *Thex )
 
 		if ( Thex->cat->et < 0.0 )
 		{
-			sprintf ( s, "Name=%s catname=%s et=%lf",
+			sprintf_s ( s, sizeof(s), "Name=%s catname=%s et=%lf",
 				Thex->name, Thex->cat->name, Thex->cat->et ) ;
 			Eprint ( "<Thexint>", s ) ;
 		}

--- a/Source/mc/mcvalv.c
+++ b/Source/mc/mcvalv.c
@@ -17,7 +17,7 @@
 
 /*  VALV */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
@@ -170,7 +170,7 @@ void	ValvControl ( FILE *fi,  int Ncompnt, COMPNT *Compnt, SCHDL *Schdl, SIMCONT
 	PELM	*Pelm ;
 
 	Vb = NULL ;
-	fscanf ( fi, "%s", s ) ;
+	fscanf_s ( fi, "%s", s, sizeof(s) ) ;
 	ad = ftell ( fi ) ;
 
 	Vc = Compntptr ( s, Ncompnt, Compnt ) ;
@@ -182,7 +182,7 @@ void	ValvControl ( FILE *fi,  int Ncompnt, COMPNT *Compnt, SCHDL *Schdl, SIMCONT
 
 	Valv = ( VALV * ) Vc->eqp ;
 	Valv->org = 'y' ;
-	while ( fscanf ( fi, "%s", s ) != EOF )
+	while ( fscanf_s ( fi, "%s", s, sizeof(s) ) != EOF )
 	{
 		if ( *s == ';' )
 		{
@@ -192,7 +192,7 @@ void	ValvControl ( FILE *fi,  int Ncompnt, COMPNT *Compnt, SCHDL *Schdl, SIMCONT
 
 		if ( strcmp ( s, "-init" ) == 0 )
 		{
-			fscanf ( fi, "%s", s ) ;
+			fscanf_s ( fi, "%s", s, sizeof(s) ) ;
 			ad = ftell ( fi ) ;
 
 			if (( k = idsch ( s, Schdl->Sch, NULL )) >= 0 )
@@ -213,7 +213,7 @@ void	ValvControl ( FILE *fi,  int Ncompnt, COMPNT *Compnt, SCHDL *Schdl, SIMCONT
 		/*******************************************/
 		else if ( strcmp ( s, "-Tout" ) == 0 )
 		{
-			fscanf ( fi, "%s", s ) ;
+			fscanf_s ( fi, "%s", s, sizeof(s) ) ;
 			ad = ftell ( fi ) ;
 
 			if (( k = idsch ( s, Schdl->Sch, NULL )) >= 0 )

--- a/Source/mc/mcvav.c
+++ b/Source/mc/mcvav.c
@@ -17,7 +17,7 @@
 
 /*  VAVコントローラ */
 
-#define _CRT_SECURE_NO_WARNINGS
+
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
@@ -94,7 +94,7 @@ void VWVint(int Nvav, VAV *VAV, int Ncompnt, COMPNT *Compn)
 
 			if ( VAV->mon == '-' )
 			{
-				sprintf ( s, "VWV(%s)=%s", VAV->name, VAV->cmp->hccname ) ;
+				sprintf_s ( s, sizeof(s), "VWV(%s)=%s", VAV->name, VAV->cmp->hccname ) ;
 				printf ( "xxxxxxxxx %s xxxxxxxxxxx\n", s ) ;
 			}
 		}
@@ -120,12 +120,12 @@ void VAVcfv(int Nvav, VAV *vav)
 		{
 			if ( vav->cat->Gmax < 0.0 )
 			{
-				sprintf ( Err, "Name=%s  Gmax=%.5g", vav->name, vav->cat->Gmax ) ;
+				sprintf_s ( Err, sizeof(Err), "Name=%s  Gmax=%.5g", vav->name, vav->cat->Gmax ) ;
 				Eprint ( "VAVcfv", Err ) ;
 			}
 			if ( vav->cat->Gmin < 0.0 )
 			{
-				sprintf ( Err, "Name=%s  Gmin=%.5g", vav->name, vav->cat->Gmin ) ;
+				sprintf_s ( Err, sizeof(Err), "Name=%s  Gmin=%.5g", vav->name, vav->cat->Gmin ) ;
 				Eprint ( "VAVcfv", Err ) ;
 			}
 

--- a/includes/MODEL.h
+++ b/includes/MODEL.h
@@ -129,9 +129,11 @@ typedef struct menn{
    int polyd ;                  /*--何角形か？--*/
 }WD_MENN ;
 
+#define OPNAME_SZ 50
+
 /*--OP（受照面）,LP（被受照面）,MP(OP+OPW)--*/
 typedef struct opmenn{
-   char   *opname ;          /*--名前--*/
+   char   opname[OPNAME_SZ] ;          /*--名前--*/
    double rgb[3] ;              /*--色--*/
    int    wd,exs ;              /*--窓の数、方位番号--*/
    double grpx,                 /*--前面地面の代表点までの距離 初期値=1---*/

--- a/includes/bl/bl_panel.h
+++ b/includes/bl/bl_panel.h
@@ -1,4 +1,4 @@
-#pragma oncce
+#pragma once
 
 void panelwp (RDPNL *rdpnl);
 void Panelcf (RDPNL *rdpnl);

--- a/includes/bl/bl_roomday.h
+++ b/includes/bl/bl_roomday.h
@@ -1,4 +1,4 @@
-#pragma oncce
+#pragma once
 
 void Roomday(int Mon, int Day, int Nday, int ttmm, int Nroom, ROOM *Rm, int Nrdpnl, RDPNL *Rdp, int SimDayend);
 void Rmdyprint(FILE *fo, char *mrk, SIMCONTL *Simc, int mon, int day, int Nroom, ROOM *Rm);

--- a/includes/common.h
+++ b/includes/common.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <stdio.h>
 

--- a/includes/ee/ee_sysupv.h
+++ b/includes/ee/ee_sysupv.h
@@ -1,3 +1,3 @@
-#pragma onece
+#pragma once
 
 void Sysupv(int Nmpath, MPATH *Mpath, RMVLS *Rmvls);

--- a/includes/func/DATAIN.h
+++ b/includes/func/DATAIN.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 void HISASHI(FILE *fi,sunblk *sb) ;
 void BARUKO(FILE *fi,sunblk *sb) ;
 void SODEK(FILE *fi,sunblk *sb) ;

--- a/includes/func/ERRPRINT.h
+++ b/includes/func/ERRPRINT.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 void errbekt_printf(int n, int m, bekt *a, char *name) ;
 

--- a/includes/func/LPOP_replacement.h
+++ b/includes/func/LPOP_replacement.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 
 

--- a/includes/func/NENNKANN.h
+++ b/includes/func/NENNKANN.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 
 /*----年間通日を求める-----*/

--- a/includes/func/ZPRINT.h
+++ b/includes/func/ZPRINT.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 //OP,LPの座標出力（デバッグ用）
 

--- a/includes/lib/u_sun.h
+++ b/includes/lib/u_sun.h
@@ -1,4 +1,4 @@
-//This file is part of EESLISM.
+﻿//This file is part of EESLISM.
 //
 //Foobar is free software : you can redistribute itand /or modify
 //it under the terms of the GNU General Public License as published by

--- a/includes/wthrd.h
+++ b/includes/wthrd.h
@@ -53,9 +53,7 @@ typedef struct wdat    /*気象デ－タ         */
 	
 	char   RNtype ;	  /*気象データ項目  C:雲量　R:夜間放射量[W/m2] */
 	
-	char	Intgtsupw ;
-						// 給水温度を補完する場合は'Y'、しない場合は'N'
-						// デフォルトは'N'
+	char	Intgtsupw ; // 給水温度を補完する場合は'Y'、しない場合は'N' (デフォルトは'N')
 	double  Twsup;     /*給水温度              */
 	double	*EarthSurface ;
 						// 地表面温度[℃]


### PR DESCRIPTION
MS VC++で警告が出ないように修正しました。
特に _CRT_SECURE_NO_WARNINGS フラグを外し文字列関数にセキュア版(_s)を使うようにしました。
strcpy ⇒ strcpy_s
strcat ⇒ strcat_s
sprintf ⇒ sprintf_s
scanf ⇒ scanf_s
等々

また、明らかにメモリ確保上危険なコードを修正しました。
その際、opnameの方を char* から char[] へ変更しました。(これ以外の方法で修正できるまではコードを理解できていないため。)

これで、ファイル読み込みを起因とするコードの脆弱性は改善されたと思います。
ただ、scanf系関数の戻値をチェックしていないのが気になります。scanfの戻り値で読み込めた項目数を取得できるので、値をチェックすることで読み込みが正常に行えたかを判断できます。
https://docs.microsoft.com/ja-jp/cpp/c-runtime-library/reference/scanf-s-scanf-s-l-wscanf-s-wscanf-s-l?view=msvc-160#return-value



